### PR TITLE
fix: wallet name not displayed in details modal

### DIFF
--- a/src/ui/molecules/RatingDetailModal.tsx
+++ b/src/ui/molecules/RatingDetailModal.tsx
@@ -499,7 +499,10 @@ function getShortExplanation(
 		if (categoryData && typeof categoryData === 'object') {
 			const attrData = (categoryData as any)[attributeId]
 			if (attrData?.evaluation?.value?.shortExplanation?.render) {
-				const rendered = attrData.evaluation.value.shortExplanation.render(evalTree.metadata || {})
+				const walletData = getWalletById(walletId)
+				const walletMetadata = walletData?.metadata || {}
+
+				const rendered = attrData.evaluation.value.shortExplanation.render(walletMetadata)
 				if (rendered) {
 					if (typeof rendered === 'object' && 'text' in rendered) {
 						return rendered.text


### PR DESCRIPTION
`RatingDetailModal` is not properly accessing wallet metadata, resulting in error messages like:

<img width="653" alt="Screenshot 2025-03-20 at 22 26 46" src="https://github.com/user-attachments/assets/13547b9e-310f-4ab0-a291-9f12ac9d4f2b" />

When rendering shortExplanations in the modal, we're not providing proper wallet metadata to the render function, so  `displayName` is undefined

Fix in this PR

<img width="706" alt="Screenshot 2025-03-20 at 22 27 13" src="https://github.com/user-attachments/assets/38c1df8f-cf22-4fcd-9ed6-f1402f92ff02" />
