### PR TITLE
Fix table heading alignments

### DIFF
--- a/src/ui/organisms/WalletTable.tsx
+++ b/src/ui/organisms/WalletTable.tsx
@@ -1049,10 +1049,11 @@ export default function WalletTable(): React.ReactElement {
 							{headerGroup.headers.map(header => (
 								<th
 									key={header.id}
-									className={`px-4 py-2 text-left text-[14px] text-[#616161] bg-gray-100 ${
+									className={`px-4 py-2 text-center text-[14px] text-[#616161] bg-gray-100 ${
 										header.column.columnDef.header === 'Wallet' ||
-										header.column.columnDef.header === 'Type'
-											? 'font-bold'
+										header.column.columnDef.header === 'Type' ||
+										header.column.columnDef.header === 'Manufacture Type'
+											? 'font-bold !text-left'
 											: header.column.columnDef.header === 'Risk by device'
 												? 'font-semibold'
 												: 'font-normal'


### PR DESCRIPTION
- Left align wallet and type headings, centre align everything else. 
- Also add bold text for 'manufacture type' column in hardware wallets

Before

<img width="1143" alt="Screenshot 2025-03-20 at 23 54 33" src="https://github.com/user-attachments/assets/e4512773-abd5-4dad-bc3e-49ca1cfe8b00" />

After

<img width="1170" alt="Screenshot 2025-03-20 at 23 54 41" src="https://github.com/user-attachments/assets/ac910a65-5636-4998-aa30-8076dd551120" />
