### PR TITLE
Add attribute categories to schema (prev hardcoded in WalletRatingCell)

### DIFF
--- a/src/schema/attributes/security/chain-verification.ts
+++ b/src/schema/attributes/security/chain-verification.ts
@@ -6,7 +6,7 @@ import {
 	type Evaluation,
 	exampleRating,
 } from '@/schema/attributes'
-import { pickWorstRating, unrated } from '../common'
+import { pickWorstRating, unrated, exempt } from '../common'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 import type { WalletMetadata } from '@/schema/wallet'
 import { isNonEmptyArray, type NonEmptyArray, nonEmptyEntries } from '@/types/utils/non-empty'
@@ -21,6 +21,7 @@ import {
 import { type FullyQualifiedReference, popRefs } from '../../reference'
 import { chainVerificationDetailsContent } from '@/types/content/chain-verification-details'
 import { isSupported, type Support } from '@/schema/features/support'
+import { WalletProfile } from '@/schema/features/profile'
 
 const brand = 'attributes.security.chain_verification'
 export type ChainVerificationValue = Value & {
@@ -150,6 +151,18 @@ export const chainVerification: Attribute<ChainVerificationValue> = {
 		),
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<ChainVerificationValue> => {
+		if (features.profile === WalletProfile.HARDWARE) {
+			return exempt(
+				chainVerification,
+				sentence(
+					(walletMetadata: WalletMetadata) =>
+						`This attribute is not applicable for ${walletMetadata.displayName} as it is a hardware wallet.`,
+				),
+				brand,
+				null,
+			)
+		}
+
 		const l1Client = features.security.lightClient.ethereumL1
 		if (l1Client === null) {
 			return unrated(chainVerification, brand, null)

--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -345,7 +345,8 @@ export const passkeyImplementation: Attribute<PasskeyImplementationValue> = {
 			),
 		],
 	},
-	aggregate: (perVariant: AtLeastOneVariant<Evaluation<PasskeyImplementationValue>>) => pickWorstRating<PasskeyImplementationValue>(perVariant),
+	aggregate: (perVariant: AtLeastOneVariant<Evaluation<PasskeyImplementationValue>>) =>
+		pickWorstRating<PasskeyImplementationValue>(perVariant),
 	evaluate: (features: ResolvedFeatures): Evaluation<PasskeyImplementationValue> => {
 		// Hardware wallets don't use passkeys
 		if (features.profile === WalletProfile.HARDWARE) {

--- a/src/schema/attributes/security/security-audits.ts
+++ b/src/schema/attributes/security/security-audits.ts
@@ -6,7 +6,7 @@ import {
 	type Evaluation,
 	exampleRating,
 } from '@/schema/attributes'
-import { pickWorstRating, unrated } from '../common'
+import { pickWorstRating, unrated, exempt } from '../common'
 import { markdown, paragraph, sentence } from '@/types/content'
 import type { WalletMetadata } from '@/schema/wallet'
 import { isNonEmptyArray, type NonEmptyArray } from '@/types/utils/non-empty'
@@ -16,6 +16,7 @@ import { securityAuditsDetailsContent } from '@/types/content/security-audits-de
 import { exampleSecurityAuditor } from '@/data/entities/example'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { mergeRefs } from '@/schema/reference'
+import { WalletProfile } from '@/schema/features/profile'
 
 const brand = 'attributes.security.security_audits'
 export type SecurityAuditsValue = Value & {
@@ -233,6 +234,18 @@ export const securityAudits: Attribute<SecurityAuditsValue> = {
 		],
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<SecurityAuditsValue> => {
+		if (features.profile === WalletProfile.HARDWARE) {
+			return exempt(
+				securityAudits,
+				sentence(
+					(walletMetadata: WalletMetadata) =>
+						`This attribute is not applicable for ${walletMetadata.displayName} as it is a hardware wallet that follows different security evaluation processes.`,
+				),
+				brand,
+				{ securityAudits: [] },
+			)
+		}
+
 		if (features.security.publicSecurityAudits === null) {
 			return unrated(securityAudits, brand, { securityAudits: [] })
 		}


### PR DESCRIPTION
When migrating from `WalletRatingCell` to `PizzaSliceChart`, a few attribute categories weren't properly excluded from the ratings chart for hardware wallets. This happened because the attribute filtering logic was applied directly in the UI layer rather than at the schema level. This PR migrates these into the schema per previous examples

Example from previous code in `WalletRatingCell`:

```js
const evalEntries = evaluatedAttributesEntries(evalGroup).filter(([attrId, evalAttr]) => {
		// Always exclude EXEMPT attributes
		if (evalAttr.evaluation.value.rating === Rating.EXEMPT) {
			return false
		}

		// For hardware wallets:
		if (isHardwareWallet) {
			// Include bug bounty program only for hardware wallets
			if (attrId === 'bugBountyProgram') {
				return true
			}

			// Exclude chain verification for hardware wallets
			if (attrId === 'chainVerification') {
				return false
			}

			// Exclude security audits for hardware wallets
			if (attrId === 'securityAudits') {
				return false
			}
		} else {
			// For non-hardware wallets, exclude the bug bounty program
			if (attrId === 'bugBountyProgram') {
				return false
			}
		}

		// Include all other attributes
		return true
	})
```