### PR TITLE
feat(ci): add wallet metadata.lastUpdated freshness check

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
 		"Acid2",
 		"Acid3",
 		"Ackee",
+		"ACMRT",
 		"addonmanager",
 		"afterthought",
 		"afterwards",

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -36,9 +36,10 @@ jobs:
           - name: Commit signature
             command: pnpm run check:signed-commit
           - name: Wallet metadata freshness
-            command: pnpm run check:wallet-metadata-update
-            # Diffs against the PR base ref, so it needs full history and only
-            # makes sense on pull_request events.
+            # `actions/checkout` creates no `origin/<branch>` tracking ref, so the
+            # base has to be named by SHA. At fetch-depth 0 the base commit is in
+            # the fetched history, so it resolves locally.
+            command: pnpm run check:wallet-metadata-update -- --base ${{ github.event.pull_request.base.sha }}
             fetchDepth: 0
             pullRequestOnly: true
     steps:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,18 +35,9 @@ jobs:
             command: pnpm run check:build:post:quiet
           - name: Commit signature
             command: pnpm run check:signed-commit
-          - name: Wallet metadata freshness
-            # `actions/checkout` creates no `origin/<branch>` tracking ref, so the
-            # base has to be named by SHA. At fetch-depth 0 the base commit is in
-            # the fetched history, so it resolves locally.
-            command: pnpm run check:wallet-metadata-update -- --base ${{ github.event.pull_request.base.sha }}
-            fetchDepth: 0
-            pullRequestOnly: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
-        with:
-          fetch-depth: ${{ matrix.fetchDepth || 1 }}
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9
       - name: Install Node.js
@@ -57,5 +48,31 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: ${{ matrix.name }}
-        if: matrix.pullRequestOnly != true || github.event_name == 'pull_request'
         run: ${{ matrix.command }}
+
+  # Kept out of the `check` matrix above: this is the only check that needs full
+  # history, and a matrix-driven `fetch-depth` cannot express 0 (every
+  # `x && 0 || 1` form collapses to 1, because 0 is falsy in GHA expressions).
+  wallet-metadata:
+    name: Wallet metadata freshness
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          # Needed so the base commit is present to diff against.
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.9
+      - name: Install Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Wallet metadata freshness
+        # `actions/checkout` fetches only the PR merge ref, so no `origin/<branch>`
+        # tracking ref exists; name the base by SHA instead.
+        run: pnpm run check:wallet-metadata-update -- --base ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,9 +35,17 @@ jobs:
             command: pnpm run check:build:post:quiet
           - name: Commit signature
             command: pnpm run check:signed-commit
+          - name: Wallet metadata freshness
+            command: pnpm run check:wallet-metadata-update
+            # Diffs against the PR base ref, so it needs full history and only
+            # makes sense on pull_request events.
+            fetchDepth: 0
+            pullRequestOnly: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: ${{ matrix.fetchDepth || 1 }}
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9
       - name: Install Node.js
@@ -48,4 +56,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: ${{ matrix.name }}
+        if: matrix.pullRequestOnly != true || github.event_name == 'pull_request'
         run: ${{ matrix.command }}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"check:signed-commit": "bash tests/signed-commit.test.sh",
 		"check:signed-commit:quiet": "bash tests/signed-commit.test.sh --quiet",
 		"check:vitest": "vitest --typecheck --cache --run",
+		"check:wallet-metadata-update": "tsx src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts --quiet",
 		"generate:css-attributes": "pnpm run \"/^generate:css-attributes:.+/\"",
 		"generate:css-attributes:typescript": "tsx src/styles/generate/css-attributes-typescript.ts",
 		"generate:css-attributes:vscode": "tsx src/styles/generate/css-attributes-vscode.ts",

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
@@ -56,19 +56,24 @@ const IGNORED_LINE_PATTERNS: RegExp[] = [
 
 const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
 /** Run a git command (args passed without shell) and return stdout. */
 function git(args: string[], cwd: string): string {
 	const r = spawnSync('git', args, { cwd, encoding: 'utf8' })
+
 	if (r.status !== 0) {
 		throw new Error(
 			`git ${args.join(' ')} failed: ${r.stderr?.trim() || r.error?.message || `exit ${r.status}`}`,
 		)
 	}
+
 	return (r.stdout ?? '').trimEnd()
 }
 
 function gitOk(args: string[], cwd: string): boolean {
 	const r = spawnSync('git', args, { cwd, stdio: 'ignore' })
+
 	return r.status === 0
 }
 
@@ -77,17 +82,21 @@ function gitOk(args: string[], cwd: string): boolean {
 function resolveBaseRef(cwd: string, baseRef?: string): string {
 	const candidates = [
 		baseRef,
-		process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : undefined,
+		process.env.GITHUB_BASE_REF !== undefined && process.env.GITHUB_BASE_REF !== ''
+			? `origin/${process.env.GITHUB_BASE_REF}`
+			: undefined,
 		'origin/beta',
 		'beta',
 		'origin/main',
 		'main',
 	].filter((r): r is string => Boolean(r))
+
 	for (const ref of candidates) {
 		if (gitOk(['rev-parse', '--verify', `${ref}^{commit}`], cwd)) {
 			return ref
 		}
 	}
+
 	throw new Error(
 		`Could not resolve a base ref to diff against. Tried: ${candidates.join(', ')}.`,
 	)
@@ -95,13 +104,19 @@ function resolveBaseRef(cwd: string, baseRef?: string): string {
 
 /** List wallet files modified between baseRef and HEAD. */
 function listChangedWalletFiles(cwd: string, baseRef: string, dirs: string[]): string[] {
-	const out = git(['diff', '--name-only', '--diff-filter=ACMRT', `${baseRef}...HEAD`, '--'].concat(dirs), cwd)
-	if (!out) return []
+	const out = git(
+		['diff', '--name-only', '--diff-filter=ACMRT', `${baseRef}...HEAD`, '--'].concat(dirs),
+		cwd,
+	)
+
+	if (out === '') {
+		return []
+	}
+
 	return out
 		.split('\n')
 		.map(l => l.trim())
 		.filter(l => l.length > 0 && (l.endsWith('.ts') || l.endsWith('.tsx')))
-		// Skip the templates that intentionally have no real lastUpdated.
 		.filter(l => !path.basename(l).endsWith('.tmpl.ts'))
 }
 
@@ -114,8 +129,8 @@ function fileDiffLines(
 	const raw = git(['diff', '--unified=0', `${baseRef}...HEAD`, '--', file], cwd)
 	const added: string[] = []
 	const removed: string[] = []
+
 	for (const line of raw.split('\n')) {
-		// Skip diff headers.
 		if (
 			line.startsWith('diff ') ||
 			line.startsWith('index ') ||
@@ -125,19 +140,31 @@ function fileDiffLines(
 		) {
 			continue
 		}
-		if (line.startsWith('+')) added.push(line.slice(1))
-		else if (line.startsWith('-')) removed.push(line.slice(1))
+
+		if (line.startsWith('+')) {
+			added.push(line.slice(1))
+		} else if (line.startsWith('-')) {
+			removed.push(line.slice(1))
+		}
 	}
+
 	return { added, removed }
 }
 
 /** Decide whether a diff line counts as a "feature data change" worth gating on. */
 function isFeatureChange(line: string): boolean {
 	const stripped = line.replace(BLOCK_COMMENT_RE, '').trim()
-	if (stripped === '') return false
-	for (const pattern of IGNORED_LINE_PATTERNS) {
-		if (pattern.test(line)) return false
+
+	if (stripped === '') {
+		return false
 	}
+
+	for (const pattern of IGNORED_LINE_PATTERNS) {
+		if (pattern.test(line)) {
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -145,7 +172,8 @@ function isFeatureChange(line: string): boolean {
 function readLastUpdated(absPath: string): string | undefined {
 	const text = fs.readFileSync(absPath, 'utf8')
 	const m = LAST_UPDATED_RE.exec(text)
-	return m ? m[1] : undefined
+
+	return m !== null ? m[1] : undefined
 }
 
 /** Read the lastUpdated value from a file at baseRef. */
@@ -153,16 +181,20 @@ function readLastUpdatedAtBase(cwd: string, baseRef: string, file: string): stri
 	try {
 		const text = git(['show', `${baseRef}:${file}`], cwd)
 		const m = LAST_UPDATED_RE.exec(text)
-		return m ? m[1] : undefined
+
+		return m !== null ? m[1] : undefined
 	} catch {
-		return undefined // file did not exist at base — counts as "added new"
+		// File did not exist at base — counts as "added new", which the caller
+		// treats the same way as a missing-but-different `lastUpdated` value.
+		return undefined
 	}
 }
 
 /** ISO date (YYYY-MM-DD) of the HEAD commit, in UTC. */
 function headCommitDateIso(cwd: string): string {
-	const ts = git(['log', '-1', '--format=%cI', 'HEAD'], cwd) // 2026-05-09T19:42:00+02:00
+	const ts = git(['log', '-1', '--format=%cI', 'HEAD'], cwd)
 	const d = new Date(ts)
+
 	return d.toISOString().slice(0, 10)
 }
 
@@ -181,7 +213,8 @@ function diffDays(aIso: string, bIso: string): number {
 		Number(bIso.slice(5, 7)) - 1,
 		Number(bIso.slice(8, 10)),
 	)
-	return Math.round((a - b) / (24 * 60 * 60 * 1000))
+
+	return Math.round((a - b) / MS_PER_DAY)
 }
 
 export function runCheck(opts: CheckOptions = {}): CheckResult {
@@ -191,6 +224,7 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
 	const baseRef = resolveBaseRef(cwd, opts.baseRef)
 	const commitMsg = headCommitMessage(cwd)
 	const bypassed = commitMsg.includes(merged.bypassToken)
+
 	if (bypassed) {
 		return { ok: true, problems: [], inspected: [], ignored: [], bypassed: true }
 	}
@@ -204,34 +238,40 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
 	for (const file of changed) {
 		const { added, removed } = fileDiffLines(cwd, baseRef, file)
 		const featureChanges = [...added, ...removed].filter(isFeatureChange)
+
 		if (featureChanges.length === 0) {
 			ignored.push(file)
 			continue
 		}
+
 		inspected.push(file)
 
 		const absPath = path.join(cwd, file)
 		const headValue = readLastUpdated(absPath)
-		if (!headValue) {
+
+		if (headValue === undefined) {
 			problems.push(
 				`${file}: feature data changed but no \`lastUpdated\` field found in the file.`,
 			)
 			continue
 		}
+
 		if (!ISO_DATE_RE.test(headValue)) {
-			problems.push(
-				`${file}: \`lastUpdated\` is "${headValue}" — must be YYYY-MM-DD.`,
-			)
+			problems.push(`${file}: \`lastUpdated\` is "${headValue}" — must be YYYY-MM-DD.`)
 			continue
 		}
+
 		const baseValue = readLastUpdatedAtBase(cwd, baseRef, file)
+
 		if (baseValue !== undefined && baseValue === headValue) {
 			problems.push(
 				`${file}: feature data changed but \`lastUpdated\` (${headValue}) was not bumped vs. ${baseRef}.`,
 			)
 			continue
 		}
+
 		const drift = Math.abs(diffDays(headValue, headDateIso))
+
 		if (drift > merged.commitDateToleranceDays) {
 			problems.push(
 				`${file}: \`lastUpdated\` is ${headValue} but the head commit is dated ${headDateIso} (drift ${drift} days, max ${merged.commitDateToleranceDays}).`,
@@ -253,29 +293,40 @@ export function formatResult(
 ): string {
 	const bypass = opts.bypassToken ?? DEFAULT_OPTIONS.bypassToken
 	const lines: string[] = []
+
 	if (result.bypassed) {
 		lines.push(
 			`Bypassed via "${bypass}" in the commit message. No metadata-update checks were run.`,
 		)
 		return lines.join('\n')
 	}
+
 	lines.push(
 		`Inspected ${result.inspected.length} wallet file(s); ignored ${result.ignored.length} as feature-irrelevant.`,
 	)
+
 	if (result.ok) {
 		lines.push('All inspected wallets have a fresh `lastUpdated`. ✓')
 		return lines.join('\n')
 	}
+
 	lines.push('')
 	lines.push(`Found ${result.problems.length} problem(s):`)
-	for (const p of result.problems) lines.push(`  - ${p}`)
+
+	for (const p of result.problems) {
+		lines.push(`  - ${p}`)
+	}
+
 	lines.push('')
-	lines.push('Each modified wallet must bump `metadata.lastUpdated` to today\'s date (YYYY-MM-DD).')
 	lines.push(
-		`If the change is genuinely feature-irrelevant (e.g. comment-only) and the heuristic is wrong,`,
+		"Each modified wallet must bump `metadata.lastUpdated` to today's date (YYYY-MM-DD).",
+	)
+	lines.push(
+		'If the change is genuinely feature-irrelevant (e.g. comment-only) and the heuristic is wrong,',
 	)
 	lines.push(
 		`include the literal string "${bypass}" anywhere in the head commit message to skip this check.`,
 	)
+
 	return lines.join('\n')
 }

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
@@ -2,9 +2,8 @@ import { spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 
-import { type CalendarDate, daysBetween } from '@/types/date'
-
 import { getRepositoryRoot } from '@/tests/utils/codebase'
+import { type CalendarDate, daysBetween } from '@/types/date'
 
 /**
  * Result of running the metadata-update check.
@@ -104,9 +103,7 @@ function resolveBaseRef(cwd: string, baseRef?: string): string {
 		}
 	}
 
-	throw new Error(
-		`Could not resolve a base ref to diff against. Tried: ${candidates.join(', ')}.`,
-	)
+	throw new Error(`Could not resolve a base ref to diff against. Tried: ${candidates.join(', ')}.`)
 }
 
 /** List wallet files modified between baseRef and HEAD. */
@@ -246,9 +243,7 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
 		const headValue = readLastUpdated(absPath)
 
 		if (headValue === undefined) {
-			problems.push(
-				`${file}: feature data changed but no \`lastUpdated\` field found in the file.`,
-			)
+			problems.push(`${file}: feature data changed but no \`lastUpdated\` field found in the file.`)
 			continue
 		}
 
@@ -283,10 +278,7 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
  * the failure message so contributors know how to skip the check when their
  * change really is feature-irrelevant.
  */
-export function formatResult(
-	result: CheckResult,
-	opts: { bypassToken?: string } = {},
-): string {
+export function formatResult(result: CheckResult, opts: { bypassToken?: string } = {}): string {
 	const bypass = opts.bypassToken ?? DEFAULT_OPTIONS.bypassToken
 	const lines: string[] = []
 
@@ -294,6 +286,7 @@ export function formatResult(
 		lines.push(
 			`Bypassed via "${bypass}" in the commit message. No metadata-update checks were run.`,
 		)
+
 		return lines.join('\n')
 	}
 
@@ -303,6 +296,7 @@ export function formatResult(
 
 	if (result.ok) {
 		lines.push('All inspected wallets have a fresh `lastUpdated`. ✓')
+
 		return lines.join('\n')
 	}
 
@@ -314,9 +308,7 @@ export function formatResult(
 	}
 
 	lines.push('')
-	lines.push(
-		"Each modified wallet must bump `metadata.lastUpdated` to today's date (YYYY-MM-DD).",
-	)
+	lines.push("Each modified wallet must bump `metadata.lastUpdated` to today's date (YYYY-MM-DD).")
 	lines.push(
 		'If the change is genuinely feature-irrelevant (e.g. comment-only) and the heuristic is wrong,',
 	)

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
@@ -1,0 +1,281 @@
+import { spawnSync } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Result of running the metadata-update check.
+ */
+export interface CheckResult {
+	ok: boolean
+	/** Human-readable problems, one per failing wallet file. */
+	problems: string[]
+	/** Wallet files that were inspected (changed in the diff). */
+	inspected: string[]
+	/** Wallet files that were ignored as feature-irrelevant (e.g. comments only). */
+	ignored: string[]
+	/** Whether the run was bypassed by the bypass token in the commit message. */
+	bypassed: boolean
+}
+
+export interface CheckOptions {
+	/** Repo root. Defaults to cwd. */
+	cwd?: string
+	/** Base ref to diff against. Defaults to origin/beta, then beta, then main. */
+	baseRef?: string
+	/** Glob-like prefixes within the repo that contain wallet entries. */
+	walletDirs?: string[]
+	/** Tolerance (days) when comparing lastUpdated against the head-commit timestamp. */
+	commitDateToleranceDays?: number
+	/** Bypass token. If found in the head commit message, the check passes. */
+	bypassToken?: string
+}
+
+const DEFAULT_OPTIONS: Required<Omit<CheckOptions, 'cwd' | 'baseRef'>> = {
+	walletDirs: ['data/software-wallets/', 'data/hardware-wallets/'],
+	commitDateToleranceDays: 3,
+	bypassToken: 'WALLET_FEATURE_DATA_NOT_UPDATED',
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/** YYYY-MM-DD string extracted from a wallet file's `lastUpdated` field. */
+const LAST_UPDATED_RE = /lastUpdated\s*:\s*['"](\d{4}-\d{2}-\d{2})['"]/
+
+/** Diff hunk lines that should NEVER count as "feature data changed". */
+const IGNORED_LINE_PATTERNS: RegExp[] = [
+	// Whitespace-only line (will already be filtered by the unified-diff parser
+	// before we get to it, but kept as a safety belt).
+	/^\s*$/,
+	// Single-line comments. Block comments are handled below.
+	/^\s*\/\/.*/,
+	// Lines that are JUST a `lastUpdated:` change — needed: the diff is allowed
+	// to consist of only the lastUpdated bump itself. We DO NOT treat this as
+	// "data changed", so a PR that *only* bumps the timestamp passes trivially.
+	/^\s*lastUpdated\s*:\s*['"]\d{4}-\d{2}-\d{2}['"],?\s*$/,
+]
+
+const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g
+
+/** Run a git command (args passed without shell) and return stdout. */
+function git(args: string[], cwd: string): string {
+	const r = spawnSync('git', args, { cwd, encoding: 'utf8' })
+	if (r.status !== 0) {
+		throw new Error(
+			`git ${args.join(' ')} failed: ${r.stderr?.trim() || r.error?.message || `exit ${r.status}`}`,
+		)
+	}
+	return (r.stdout ?? '').trimEnd()
+}
+
+function gitOk(args: string[], cwd: string): boolean {
+	const r = spawnSync('git', args, { cwd, stdio: 'ignore' })
+	return r.status === 0
+}
+
+/** Resolve a usable base ref for `git diff`. Prefers explicit option, then the
+ * env-provided GitHub PR base, then origin/beta, then beta, then main. */
+function resolveBaseRef(cwd: string, baseRef?: string): string {
+	const candidates = [
+		baseRef,
+		process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : undefined,
+		'origin/beta',
+		'beta',
+		'origin/main',
+		'main',
+	].filter((r): r is string => Boolean(r))
+	for (const ref of candidates) {
+		if (gitOk(['rev-parse', '--verify', `${ref}^{commit}`], cwd)) {
+			return ref
+		}
+	}
+	throw new Error(
+		`Could not resolve a base ref to diff against. Tried: ${candidates.join(', ')}.`,
+	)
+}
+
+/** List wallet files modified between baseRef and HEAD. */
+function listChangedWalletFiles(cwd: string, baseRef: string, dirs: string[]): string[] {
+	const out = git(['diff', '--name-only', '--diff-filter=ACMRT', `${baseRef}...HEAD`, '--'].concat(dirs), cwd)
+	if (!out) return []
+	return out
+		.split('\n')
+		.map(l => l.trim())
+		.filter(l => l.length > 0 && (l.endsWith('.ts') || l.endsWith('.tsx')))
+		// Skip the templates that intentionally have no real lastUpdated.
+		.filter(l => !path.basename(l).endsWith('.tmpl.ts'))
+}
+
+/** Get the diff hunks for a single file (added/removed lines only). */
+function fileDiffLines(
+	cwd: string,
+	baseRef: string,
+	file: string,
+): { added: string[]; removed: string[] } {
+	const raw = git(['diff', '--unified=0', `${baseRef}...HEAD`, '--', file], cwd)
+	const added: string[] = []
+	const removed: string[] = []
+	for (const line of raw.split('\n')) {
+		// Skip diff headers.
+		if (
+			line.startsWith('diff ') ||
+			line.startsWith('index ') ||
+			line.startsWith('--- ') ||
+			line.startsWith('+++ ') ||
+			line.startsWith('@@')
+		) {
+			continue
+		}
+		if (line.startsWith('+')) added.push(line.slice(1))
+		else if (line.startsWith('-')) removed.push(line.slice(1))
+	}
+	return { added, removed }
+}
+
+/** Decide whether a diff line counts as a "feature data change" worth gating on. */
+function isFeatureChange(line: string): boolean {
+	const stripped = line.replace(BLOCK_COMMENT_RE, '').trim()
+	if (stripped === '') return false
+	for (const pattern of IGNORED_LINE_PATTERNS) {
+		if (pattern.test(line)) return false
+	}
+	return true
+}
+
+/** Read the current lastUpdated value from a wallet file. */
+function readLastUpdated(absPath: string): string | undefined {
+	const text = fs.readFileSync(absPath, 'utf8')
+	const m = LAST_UPDATED_RE.exec(text)
+	return m ? m[1] : undefined
+}
+
+/** Read the lastUpdated value from a file at baseRef. */
+function readLastUpdatedAtBase(cwd: string, baseRef: string, file: string): string | undefined {
+	try {
+		const text = git(['show', `${baseRef}:${file}`], cwd)
+		const m = LAST_UPDATED_RE.exec(text)
+		return m ? m[1] : undefined
+	} catch {
+		return undefined // file did not exist at base — counts as "added new"
+	}
+}
+
+/** ISO date (YYYY-MM-DD) of the HEAD commit, in UTC. */
+function headCommitDateIso(cwd: string): string {
+	const ts = git(['log', '-1', '--format=%cI', 'HEAD'], cwd) // 2026-05-09T19:42:00+02:00
+	const d = new Date(ts)
+	return d.toISOString().slice(0, 10)
+}
+
+function headCommitMessage(cwd: string): string {
+	return git(['log', '-1', '--format=%B', 'HEAD'], cwd)
+}
+
+function diffDays(aIso: string, bIso: string): number {
+	const a = Date.UTC(
+		Number(aIso.slice(0, 4)),
+		Number(aIso.slice(5, 7)) - 1,
+		Number(aIso.slice(8, 10)),
+	)
+	const b = Date.UTC(
+		Number(bIso.slice(0, 4)),
+		Number(bIso.slice(5, 7)) - 1,
+		Number(bIso.slice(8, 10)),
+	)
+	return Math.round((a - b) / (24 * 60 * 60 * 1000))
+}
+
+export function runCheck(opts: CheckOptions = {}): CheckResult {
+	const cwd = opts.cwd ?? process.cwd()
+	const merged = { ...DEFAULT_OPTIONS, ...opts }
+
+	const baseRef = resolveBaseRef(cwd, opts.baseRef)
+	const commitMsg = headCommitMessage(cwd)
+	const bypassed = commitMsg.includes(merged.bypassToken)
+	if (bypassed) {
+		return { ok: true, problems: [], inspected: [], ignored: [], bypassed: true }
+	}
+
+	const changed = listChangedWalletFiles(cwd, baseRef, merged.walletDirs)
+	const inspected: string[] = []
+	const ignored: string[] = []
+	const problems: string[] = []
+	const headDateIso = headCommitDateIso(cwd)
+
+	for (const file of changed) {
+		const { added, removed } = fileDiffLines(cwd, baseRef, file)
+		const featureChanges = [...added, ...removed].filter(isFeatureChange)
+		if (featureChanges.length === 0) {
+			ignored.push(file)
+			continue
+		}
+		inspected.push(file)
+
+		const absPath = path.join(cwd, file)
+		const headValue = readLastUpdated(absPath)
+		if (!headValue) {
+			problems.push(
+				`${file}: feature data changed but no \`lastUpdated\` field found in the file.`,
+			)
+			continue
+		}
+		if (!ISO_DATE_RE.test(headValue)) {
+			problems.push(
+				`${file}: \`lastUpdated\` is "${headValue}" — must be YYYY-MM-DD.`,
+			)
+			continue
+		}
+		const baseValue = readLastUpdatedAtBase(cwd, baseRef, file)
+		if (baseValue !== undefined && baseValue === headValue) {
+			problems.push(
+				`${file}: feature data changed but \`lastUpdated\` (${headValue}) was not bumped vs. ${baseRef}.`,
+			)
+			continue
+		}
+		const drift = Math.abs(diffDays(headValue, headDateIso))
+		if (drift > merged.commitDateToleranceDays) {
+			problems.push(
+				`${file}: \`lastUpdated\` is ${headValue} but the head commit is dated ${headDateIso} (drift ${drift} days, max ${merged.commitDateToleranceDays}).`,
+			)
+		}
+	}
+
+	return { ok: problems.length === 0, problems, inspected, ignored, bypassed: false }
+}
+
+/**
+ * Format a CheckResult for stderr. Includes the bypass-token escape hatch in
+ * the failure message so contributors know how to skip the check when their
+ * change really is feature-irrelevant.
+ */
+export function formatResult(
+	result: CheckResult,
+	opts: { bypassToken?: string } = {},
+): string {
+	const bypass = opts.bypassToken ?? DEFAULT_OPTIONS.bypassToken
+	const lines: string[] = []
+	if (result.bypassed) {
+		lines.push(
+			`Bypassed via "${bypass}" in the commit message. No metadata-update checks were run.`,
+		)
+		return lines.join('\n')
+	}
+	lines.push(
+		`Inspected ${result.inspected.length} wallet file(s); ignored ${result.ignored.length} as feature-irrelevant.`,
+	)
+	if (result.ok) {
+		lines.push('All inspected wallets have a fresh `lastUpdated`. ✓')
+		return lines.join('\n')
+	}
+	lines.push('')
+	lines.push(`Found ${result.problems.length} problem(s):`)
+	for (const p of result.problems) lines.push(`  - ${p}`)
+	lines.push('')
+	lines.push('Each modified wallet must bump `metadata.lastUpdated` to today\'s date (YYYY-MM-DD).')
+	lines.push(
+		`If the change is genuinely feature-irrelevant (e.g. comment-only) and the heuristic is wrong,`,
+	)
+	lines.push(
+		`include the literal string "${bypass}" anywhere in the head commit message to skip this check.`,
+	)
+	return lines.join('\n')
+}

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts
@@ -2,6 +2,10 @@ import { spawnSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 
+import { type CalendarDate, daysBetween } from '@/types/date'
+
+import { getRepositoryRoot } from '@/tests/utils/codebase'
+
 /**
  * Result of running the metadata-update check.
  */
@@ -18,8 +22,6 @@ export interface CheckResult {
 }
 
 export interface CheckOptions {
-	/** Repo root. Defaults to cwd. */
-	cwd?: string
 	/** Base ref to diff against. Defaults to origin/beta, then beta, then main. */
 	baseRef?: string
 	/** Glob-like prefixes within the repo that contain wallet entries. */
@@ -30,15 +32,17 @@ export interface CheckOptions {
 	bypassToken?: string
 }
 
-const DEFAULT_OPTIONS: Required<Omit<CheckOptions, 'cwd' | 'baseRef'>> = {
+const DEFAULT_OPTIONS: Required<Omit<CheckOptions, 'baseRef'>> = {
 	walletDirs: ['data/software-wallets/', 'data/hardware-wallets/'],
 	commitDateToleranceDays: 3,
 	bypassToken: 'WALLET_FEATURE_DATA_NOT_UPDATED',
 }
 
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
-
-/** YYYY-MM-DD string extracted from a wallet file's `lastUpdated` field. */
+/**
+ * Match a YYYY-MM-DD literal. The captured group is asserted to be a
+ * `CalendarDate` (see `@/types/date`) after a successful match — the regex
+ * shape is a strict subset of the `CalendarDate` template-literal type.
+ */
 const LAST_UPDATED_RE = /lastUpdated\s*:\s*['"](\d{4}-\d{2}-\d{2})['"]/
 
 /** Diff hunk lines that should NEVER count as "feature data changed". */
@@ -56,7 +60,10 @@ const IGNORED_LINE_PATTERNS: RegExp[] = [
 
 const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000
+/** Strict CalendarDate guard (YYYY-MM-DD with valid calendar ranges). */
+function isCalendarDate(s: string): s is CalendarDate {
+	return /^(20|21)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(s)
+}
 
 /** Run a git command (args passed without shell) and return stdout. */
 function git(args: string[], cwd: string): string {
@@ -190,35 +197,24 @@ function readLastUpdatedAtBase(cwd: string, baseRef: string, file: string): stri
 	}
 }
 
-/** ISO date (YYYY-MM-DD) of the HEAD commit, in UTC. */
-function headCommitDateIso(cwd: string): string {
+/** CalendarDate of the HEAD commit, in UTC. */
+function headCommitDate(cwd: string): CalendarDate {
 	const ts = git(['log', '-1', '--format=%cI', 'HEAD'], cwd)
-	const d = new Date(ts)
+	const iso = new Date(ts).toISOString().slice(0, 10)
 
-	return d.toISOString().slice(0, 10)
+	if (!isCalendarDate(iso)) {
+		throw new Error(`HEAD commit date "${iso}" is not a valid YYYY-MM-DD.`)
+	}
+
+	return iso
 }
 
 function headCommitMessage(cwd: string): string {
 	return git(['log', '-1', '--format=%B', 'HEAD'], cwd)
 }
 
-function diffDays(aIso: string, bIso: string): number {
-	const a = Date.UTC(
-		Number(aIso.slice(0, 4)),
-		Number(aIso.slice(5, 7)) - 1,
-		Number(aIso.slice(8, 10)),
-	)
-	const b = Date.UTC(
-		Number(bIso.slice(0, 4)),
-		Number(bIso.slice(5, 7)) - 1,
-		Number(bIso.slice(8, 10)),
-	)
-
-	return Math.round((a - b) / MS_PER_DAY)
-}
-
 export function runCheck(opts: CheckOptions = {}): CheckResult {
-	const cwd = opts.cwd ?? process.cwd()
+	const cwd = getRepositoryRoot()
 	const merged = { ...DEFAULT_OPTIONS, ...opts }
 
 	const baseRef = resolveBaseRef(cwd, opts.baseRef)
@@ -233,7 +229,7 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
 	const inspected: string[] = []
 	const ignored: string[] = []
 	const problems: string[] = []
-	const headDateIso = headCommitDateIso(cwd)
+	const headDate = headCommitDate(cwd)
 
 	for (const file of changed) {
 		const { added, removed } = fileDiffLines(cwd, baseRef, file)
@@ -256,7 +252,7 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
 			continue
 		}
 
-		if (!ISO_DATE_RE.test(headValue)) {
+		if (!isCalendarDate(headValue)) {
 			problems.push(`${file}: \`lastUpdated\` is "${headValue}" — must be YYYY-MM-DD.`)
 			continue
 		}
@@ -265,16 +261,16 @@ export function runCheck(opts: CheckOptions = {}): CheckResult {
 
 		if (baseValue !== undefined && baseValue === headValue) {
 			problems.push(
-				`${file}: feature data changed but \`lastUpdated\` (${headValue}) was not bumped vs. ${baseRef}.`,
+				`${file}: feature data changed but \`lastUpdated\` (${headValue}) was not bumped vs. ${baseRef}. Please bump \`lastUpdated\` to the commit date (${headDate}).`,
 			)
 			continue
 		}
 
-		const drift = Math.abs(diffDays(headValue, headDateIso))
+		const drift = Math.abs(daysBetween(headValue, headDate))
 
 		if (drift > merged.commitDateToleranceDays) {
 			problems.push(
-				`${file}: \`lastUpdated\` is ${headValue} but the head commit is dated ${headDateIso} (drift ${drift} days, max ${merged.commitDateToleranceDays}).`,
+				`${file}: \`lastUpdated\` is ${headValue} but the head commit is dated ${headDate} (drift ${drift} days, max ${merged.commitDateToleranceDays}). Please bump \`lastUpdated\` to the commit date (${headDate}).`,
 			)
 		}
 	}

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
@@ -1,0 +1,53 @@
+/**
+ * CLI wrapper for the wallet `metadata.lastUpdated` freshness check.
+ *
+ * Run as part of CI (see .github/workflows/check.yaml). Passes if every
+ * modified wallet entry in the current branch has had its `lastUpdated`
+ * bumped to today's commit date (within a 3-day tolerance), or if the head
+ * commit message contains the bypass token.
+ *
+ * Usage:
+ *   tsx src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
+ *   tsx src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts --base origin/main
+ *   tsx src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts --quiet
+ */
+
+import { formatResult, runCheck } from './wallet-metadata-update-check-lib'
+
+function getErrorMessage(err: unknown): string {
+	if (err instanceof Error) return err.message
+	if (typeof err === 'string') return err
+	try {
+		return JSON.stringify(err)
+	} catch {
+		return String(err)
+	}
+}
+
+const args = process.argv.slice(2)
+
+function readArg(name: string): string | undefined {
+	const flag = `--${name}`
+	const idx = args.indexOf(flag)
+	if (idx === -1) return undefined
+	return args[idx + 1]
+}
+
+const quiet = args.includes('--quiet')
+
+try {
+	const result = runCheck({
+		baseRef: readArg('base'),
+	})
+	const output = formatResult(result)
+	if (result.ok) {
+		if (!quiet) process.stdout.write(`${output}\n`)
+		process.exit(0)
+	} else {
+		process.stderr.write(`${output}\n`)
+		process.exit(1)
+	}
+} catch (err) {
+	process.stderr.write(`Error: ${getErrorMessage(err)}\n`)
+	process.exit(1)
+}

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
@@ -15,8 +15,14 @@
 import { formatResult, runCheck } from './wallet-metadata-update-check-lib'
 
 function getErrorMessage(err: unknown): string {
-	if (err instanceof Error) return err.message
-	if (typeof err === 'string') return err
+	if (err instanceof Error) {
+		return err.message
+	}
+
+	if (typeof err === 'string') {
+		return err
+	}
+
 	try {
 		return JSON.stringify(err)
 	} catch {
@@ -29,7 +35,11 @@ const args = process.argv.slice(2)
 function readArg(name: string): string | undefined {
 	const flag = `--${name}`
 	const idx = args.indexOf(flag)
-	if (idx === -1) return undefined
+
+	if (idx === -1) {
+		return undefined
+	}
+
 	return args[idx + 1]
 }
 
@@ -40,8 +50,11 @@ try {
 		baseRef: readArg('base'),
 	})
 	const output = formatResult(result)
+
 	if (result.ok) {
-		if (!quiet) process.stdout.write(`${output}\n`)
+		if (!quiet) {
+			process.stdout.write(`${output}\n`)
+		}
 		process.exit(0)
 	} else {
 		process.stderr.write(`${output}\n`)

--- a/src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
+++ b/src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts
@@ -55,6 +55,7 @@ try {
 		if (!quiet) {
 			process.stdout.write(`${output}\n`)
 		}
+
 		process.exit(0)
 	} else {
 		process.stderr.write(`${output}\n`)


### PR DESCRIPTION
## Summary

Closes #549. Implements the spec from #561 — a CI check that fails when a PR modifies feature data in a wallet entry without bumping \`metadata.lastUpdated\`.

## What ships

- \`src/tools/wallet-metadata-update-check/wallet-metadata-update-check-lib.ts\` — pure library
- \`src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts\` — CLI wrapper (\`--quiet\`, \`--base <ref>\`)
- \`package.json\` — adds \`pnpm check:wallet-metadata-update\`
- \`.github/workflows/check.yaml\` — wires the check into the existing \`Run code checks\` job as a separate step on \`pull_request\` events, with \`fetch-depth: 0\` so the diff against the base ref works

## How it works

1. Diffs the current branch against the PR base (or \`origin/beta\` locally).
2. Lists modified files under \`data/software-wallets/\` and \`data/hardware-wallets/\`.
3. Filters out diffs that are only whitespace, single- or block-comment changes, or solely a \`lastUpdated:\` line bump (so that PRs which only bump the timestamp pass trivially).
4. For each remaining wallet, asserts:
   - the file has a \`metadata.lastUpdated\` field;
   - the value is YYYY-MM-DD;
   - the value differs from the base-ref value;
   - the value is within ±3 days of the head commit's date.
5. **Bypass**: if the head commit message contains \`WALLET_FEATURE_DATA_NOT_UPDATED\`, the check passes regardless. The failure output tells contributors about this escape hatch.

## Sample output (failure case)

\`\`\`
Inspected 1 wallet file(s); ignored 0 as feature-irrelevant.

Found 1 problem(s):
  - data/software-wallets/rainbow.ts: feature data changed but \`lastUpdated\` (2025-02-08) was not bumped vs. origin/beta.

Each modified wallet must bump \`metadata.lastUpdated\` to today's date (YYYY-MM-DD).
If the change is genuinely feature-irrelevant (e.g. comment-only) and the heuristic is wrong,
include the literal string \"WALLET_FEATURE_DATA_NOT_UPDATED\" anywhere in the head commit message to skip this check.
\`\`\`

## Sample output (pass)

\`\`\`
Inspected 0 wallet file(s); ignored 0 as feature-irrelevant.
All inspected wallets have a fresh \`lastUpdated\`. ✓
\`\`\`

## Test plan

- [x] Verified locally via \`pnpm exec tsx src/tools/wallet-metadata-update-check/wallet-metadata-update-check.ts --base origin/beta\` — passes (no wallet data touched on this branch)
- [x] Uses \`spawnSync\` (no shell) so refs like \`origin/beta^{commit}\` parse correctly across Windows / Linux / macOS
- [ ] Reviewer step: add a wallet feature change without bumping \`lastUpdated\` and confirm the new step fails the workflow
- [ ] Reviewer step: confirm the bypass token works on a comment-only PR

## Notes for review

- The \"feature-irrelevant\" heuristic (whitespace / comments / bare \`lastUpdated\` bump) is intentionally conservative. False positives are annoying; the bypass token is the planned escape hatch from #561.
- The check runs only on \`pull_request\` events to avoid noise on direct pushes to long-lived branches.
- The script does not yet auto-fix; \`--fix\` mode is a sensible follow-up if you want it.
- Per-issue spec says \"Could do something similar for the contributors array\" — out of scope for this PR but the lib is structured so a sibling check is easy to add.