### PR TITLE
Move site disclaimer into the footer

### DIFF
--- a/src/views/Footer.astro
+++ b/src/views/Footer.astro
@@ -22,42 +22,49 @@ const socialLinks = [
 ] as const
 ---
 
-<footer data-row='center wrap align-center gap-6' data-scroll-item='inline-detached'>
-	<a href='/' data-link='camouflaged' data-row-item='wrap-center' aria-label='Walletbeat'>
-		<img src='/logo.svg' alt='Walletbeat' data-safari='invert-lightness' />
-	</a>
-
-	<p data-row-item='wrap-center basis-6'>
-		Made with 🌸 & 💗 by the {' '}
-		<a
-			href='https://github.com/walletbeat/walletbeat/graphs/contributors?all=1'
-			target='_blank'
-			rel='noreferrer'
-		>
-			Walletbeat contributors
+<footer data-column='gap-4' data-scroll-item='inline-detached'>
+	<div data-row='center wrap align-center gap-6'>
+		<a href='/' data-link='camouflaged' data-row-item='wrap-center' aria-label='Walletbeat'>
+			<img src='/logo.svg' alt='Walletbeat' data-safari='invert-lightness' />
 		</a>
-	</p>
 
-	<nav data-row='center' data-row-item='wrap-center' aria-label='Walletbeat links'>
-		<ul data-list='unstyled' data-row='center'>
-			{
-				socialLinks.map(link => (
-					<li>
-						<a
-							data-icon='circle'
-							href={link.href}
-							target='_blank'
-							rel='noreferrer'
-							aria-label={link.label}
-							title={link.label}
-						>
-							<span set:html={link.icon} />
-						</a>
-					</li>
-				))
-			}
-		</ul>
-	</nav>
+		<p data-row-item='wrap-center basis-6'>
+			Made with 🌸 & 💗 by the {' '}
+			<a
+				href='https://github.com/walletbeat/walletbeat/graphs/contributors?all=1'
+				target='_blank'
+				rel='noreferrer'
+			>
+				Walletbeat contributors
+			</a>
+		</p>
+
+		<nav data-row='center' data-row-item='wrap-center' aria-label='Walletbeat links'>
+			<ul data-list='unstyled' data-row='center'>
+				{
+					socialLinks.map(link => (
+						<li>
+							<a
+								data-icon='circle'
+								href={link.href}
+								target='_blank'
+								rel='noreferrer'
+								aria-label={link.label}
+								title={link.label}
+							>
+								<span set:html={link.icon} />
+							</a>
+						</li>
+					))
+				}
+			</ul>
+		</nav>
+	</div>
+
+	<p class='disclaimer'>
+		Wallets listed on Walletbeat do not represent endorsements and are for informational purposes
+		only.
+	</p>
 </footer>
 
 <style>
@@ -83,6 +90,12 @@ const socialLinks = [
 			color: var(--footer-mutedColor);
 			font-size: 0.8125rem;
 			line-height: 1.4;
+		}
+
+		.disclaimer {
+			margin: 0;
+			max-inline-size: 42rem;
+			margin-inline: auto;
 		}
 	}
 </style>

--- a/src/views/Navigation.astro
+++ b/src/views/Navigation.astro
@@ -75,13 +75,6 @@ const secondaryNavigationItems = [
 			groups={[{ items: navigationItems }, { items: secondaryNavigationItems }]}
 			currentHref={currentHref}
 		/>
-
-		<footer data-card data-sticky='backdrop-self backdrop-always' data-sticky-container>
-			<p>
-				Wallets listed on Walletbeat do not represent endorsements and are for informational
-				purposes only.
-			</p>
-		</footer>
 	</div>
 </nav>
 
@@ -132,8 +125,6 @@ const secondaryNavigationItems = [
 		}
 
 		#nav-menu {
-			--navigation-footer-sidestepBlock: 1rem;
-
 			position: relative;
 			z-index: 0;
 			align-content: stretch;
@@ -143,25 +134,9 @@ const secondaryNavigationItems = [
 			&[data-sticky-container] {
 				--sticky-marginBlockStart: var(--navigation-mobile-blockSize);
 				--sticky-paddingBlockStart: 1rem;
-				--sticky-paddingBlockEnd: var(--navigation-footer-sidestepBlock);
+				--sticky-paddingBlockEnd: 1rem;
 				--sticky-paddingInlineStart: 0.75rem;
 				--sticky-paddingInlineEnd: 0.75rem;
-			}
-
-			footer {
-				&[data-card] {
-					--card-backgroundColor: color-mix(
-						in oklch,
-						var(--background-secondary) 82%,
-						var(--accent)
-					);
-
-					p {
-						line-height: 1.4;
-						font-size: 0.875rem;
-						color: var(--text-secondary);
-					}
-				}
 			}
 		}
 	}
@@ -195,10 +170,6 @@ const secondaryNavigationItems = [
 					display: block;
 					order: 3;
 					margin-block-start: 1rem;
-				}
-
-				> footer {
-					display: none;
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Move the Walletbeat disclaimer out of the left sidebar into the site footer
- Keep footer layout readable with the added disclaimer copy

## Test plan
- [ ] Confirm disclaimer no longer appears in the left nav footer area
- [ ] Confirm disclaimer appears in the site footer on desktop and mobile