### PR TITLE
Fix "Source Code" link never rendering for any wallet

### DIFF
--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -626,9 +626,9 @@
 						Website
 					</a>
 
-					{#if wallet.metadata.urls?.repository}
+					{#if wallet.metadata.urls?.repositories?.[0] !== undefined}
 						<a
-							href={isLabeledUrl(wallet.metadata.urls.repository[0]) ? wallet.metadata.urls.repository[0].url : wallet.metadata.urls.repository[0]}
+							href={isLabeledUrl(wallet.metadata.urls.repositories[0]) ? wallet.metadata.urls.repositories[0].url : wallet.metadata.urls.repositories[0]}
 							data-badge="medium"
 							target="_blank"
 							rel="noopener noreferrer"

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1017,11 +1017,11 @@
 										Website
 									</a>
 
-									{#if wallet.metadata.urls?.repository}
+									{#if wallet.metadata.urls?.repositories?.[0] !== undefined}
 										<hr>
 
 										<a
-											href={isLabeledUrl(wallet.metadata.urls.repository[0]) ? wallet.metadata.urls.repository[0].url : wallet.metadata.urls.repository[0]}
+											href={isLabeledUrl(wallet.metadata.urls.repositories[0]) ? wallet.metadata.urls.repositories[0].url : wallet.metadata.urls.repositories[0]}
 											target="_blank"
 											rel="noopener noreferrer"
 										>


### PR DESCRIPTION
## Summary

Fixes #906.

Both views read `wallet.metadata.urls?.repository` (singular), but the schema field is
`repositories` (plural). `repository` is not a key of `WalletUrls`, so it was always
`undefined` and the "Source Code" link was silently omitted for every wallet — including the
29 that declare a repository URL.

- `src/views/WalletPage.svelte` — detail page header nav
- `src/views/WalletTable.svelte` — expanded wallet card in the comparison table

## Changes

Renamed the four reads to `repositories`.

Also tightened the guard to `?.repositories?.[0] !== undefined`. `repositories` is `Url[]`, and
an empty array is truthy, so a bare truthiness check would enter the block and render a "Source
Code" anchor with no `href` (Svelte omits nullish attributes), plus a stray `<hr>` in the table
variant. No wallet currently declares an empty array, so this is defensive only; it matches the
check `wallet-json-export.ts` already uses.


<img width="790" height="134" alt="image" src="https://github.com/user-attachments/assets/7876cc2f-d8e5-4f6c-af69-92c3041f2bf3" />

<img width="803" height="215" alt="image" src="https://github.com/user-attachments/assets/ecadd0eb-b190-49d2-9f9c-a11b3c955912" />


