### PR TITLE
Set SITE_URL for the beta deploy so it stops emitting wallet.page URLs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - beta
 
+env:
+  ENS_DOMAIN: beta.walletbeat.eth
+
 jobs:
   check:
     name: Check and build
@@ -36,6 +39,7 @@ jobs:
           rm -rf dist &>/dev/null || true
           pnpm build
         env:
+          SITE_URL: https://${{ env.ENS_DOMAIN }}.limo
           WALLETBEAT_ENV: CI
           WALLETBEAT_BUILD_MUST_BE_SANDBOXED: true
           WALLETBEAT_MUST_INSTALL_DEPENDENCIES_CLEANLY: true
@@ -131,7 +135,6 @@ jobs:
       - name: Update beta.walletbeat.eth ENS records
         run: ./deploy/update-ens.sh
         env:
-          ENS_DOMAIN: beta.walletbeat.eth
           DEPLOY_DIRECTORY: dist
           OMNIPIN_PK: ${{ secrets.BETA_WALLETBEAT_ETH_UPDATER_EOA_PRIVATE_KEY }}
           SKIP_HELIOS: 'false'


### PR DESCRIPTION
https://beta.walletbeat.eth.limo/llms.txt

```md
## Software Wallets

- [Ambire](https://wallet.page/ambire/index.html.md)
- [Base App](https://wallet.page/base-app/index.html.md)
- [Bitget Wallet](https://wallet.page/bitget/index.html.md)
```

The beta site emits `https://wallet.page/<wallet>/index.html.md` links, and those paths don't currently serve walletbeat wallet pages — wallet.page is running the EIP/RPC support docs app, an SPA that returns 200 for any path, so the links resolve to the wrong content instead of 404ing. A crawler following them ingests the wrong site silently.

The same value reaches the `.md` and `.json` wallet pages, both sitemaps, and `og:image` across 72 pages. It isn't visible via `astro dev`, since `getBaseUrl()` returns localhost in development before it ever reads `site`.

Cause, as best I can tell: `astro.config.mjs` sets `site: 'https://wallet.page'`, which looks correct for production. `deploy.yaml` publishes to `beta.walletbeat.eth` but never sets `SITE_URL`, so the beta build inherits the production host.

## Change

Set `SITE_URL` for the beta deploy only, derived from `ENS_DOMAIN` — promoted to workflow-level env so the build job can read it (it lives in the `update-ens` job today, and jobs don't share env). The step-level value it replaces is identical, so the ENS step is unchanged. `astro.config.mjs` is untouched.

## Tradeoff

Uses the eth.limo gateway rather than `beta.walletbeat.eth` itself, because `llms.txt` and the sitemaps are consumed by crawlers that can't resolve `.eth`. Cost: the gateway is baked into build-time URLs, so beta content served through dweb.link or another gateway still points at eth.limo. Client-side URLs are unaffected — `getBaseUrl()` prefers `window.location`.

## Notes

Verified locally that `SITE_URL` survives `deploy/build.sh`'s bwrap sandbox and reaches `astro build`, so the workflow value takes effect. I can't test the workflow itself.

If beta is meant to advertise wallet.page, or the domain setup is mid-migration, feel free to close — the broken links were the thing worth flagging. See the comment below for a correction to this PR's original framing.
