### PR TITLE
CI: Fix filesize test CI on Mac

### DIFF
--- a/tests/postbuild/filesize_test.sh
+++ b/tests/postbuild/filesize_test.sh
@@ -34,7 +34,7 @@ while IFS= read -r f; do
 		continue
 	fi
 	rel="${f#"$DIST_DIR"/}"
-	size="$(stat -f '%z' "$f" 2>/dev/null || stat -c '%s' "$f")"
+	size="$(wc -c < "$f")"
 	if is_known_too_large "$f"; then
 		if ((size <= MAX_BYTES)); then
 			# The file is no longer oversized, so its KNOWN_TOO_LARGE entry is stale.

--- a/tests/postbuild/filesize_test.sh
+++ b/tests/postbuild/filesize_test.sh
@@ -20,7 +20,7 @@ is_known_too_large() {
 	local f="$1"
 	local rel="${f#"$DIST_DIR"/}"
 	local known
-	for known in "${KNOWN_TOO_LARGE[@]}"; do
+	for known in "${KNOWN_TOO_LARGE[@]+"${KNOWN_TOO_LARGE[@]}"}"; do
 		if [[ "$rel" == "$known" ]]; then
 			return 0
 		fi
@@ -34,7 +34,7 @@ while IFS= read -r f; do
 		continue
 	fi
 	rel="${f#"$DIST_DIR"/}"
-	size="$(stat -c '%s' "$f")"
+	size="$(stat -f '%z' "$f" 2>/dev/null || stat -c '%s' "$f")"
 	if is_known_too_large "$f"; then
 		if ((size <= MAX_BYTES)); then
 			# The file is no longer oversized, so its KNOWN_TOO_LARGE entry is stale.


### PR DESCRIPTION
CI: Fix filesize test CI on Mac

`tests/postbuild/filesize_test.sh` used `stat -c '%s'`, which is GNU-only syntax — BSD `stat` on macOS doesn't support `-c` and fails with `stat: illegal option -- c`. Falls back to `stat -f '%z'` first.

Also fixed `"${KNOWN_TOO_LARGE[@]}"` tripping `set -u`'s unbound-variable check on an empty array under macOS's bash 3.2.

Closes #1133