### PR TITLE
Zerion: Assess mobile app security best practices as unverifiable

### DIFF
--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -561,7 +561,7 @@ export const zerion: SoftwareWallet = {
 					secureRng: SecureRngSource.OS_CSPRNG,
 				},
 				desktop: 'NOT_A_DESKTOP_APP',
-				mobile: 'NOT_A_MOBILE_APP',
+				mobile: 'SOURCE_NOT_AVAILABLE',
 			},
 			transactionLegibility: {
 				ref: refTodo,


### PR DESCRIPTION
Zerion's `securityBestPractices.mobile` incorrectly stated the wallet has no mobile app; updated to `'SOURCE_NOT_AVAILABLE'`, since Zerion ships one but does not publish its source.