### PR TITLE
Rainbow: Correct and source the app unlock mechanisms

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -82,7 +82,7 @@ export const rainbow: SoftwareWallet = {
 		tableName: 'Rainbow',
 		contributors: [polymutex, mattmatt, ren2140],
 		iconExtension: 'svg',
-		lastUpdated: '2026-08-20',
+		lastUpdated: '2026-08-22',
 		urls: {
 			androidManifestXml:
 				'https://raw.githubusercontent.com/rainbow-me/rainbow/develop/android/app/src/main/AndroidManifest.xml',
@@ -733,18 +733,55 @@ export const rainbow: SoftwareWallet = {
 				}),
 			},
 			bugBountyProgram: notSupported,
-			duressResistance: supported({
-				basicUnlock: {
-					ref: refTodo,
-					mechanisms: {
-						[BasicUnlockMechanism.PIN]: false,
-						[BasicUnlockMechanism.PASSWORD]: true,
-						[BasicUnlockMechanism.BIOMETRIC]: false,
-						[BasicUnlockMechanism.PATTERN]: false,
+			duressResistance: {
+				[Variant.BROWSER]: supported({
+					basicUnlock: {
+						ref: {
+							explanation: 'The extension is unlocked with a password.',
+							label: 'Extension unlock screen source code',
+							url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/unlock/index.tsx',
+						},
+						mechanisms: {
+							[BasicUnlockMechanism.PIN]: false,
+							[BasicUnlockMechanism.PASSWORD]: true,
+							[BasicUnlockMechanism.BIOMETRIC]: false,
+							[BasicUnlockMechanism.PATTERN]: false,
+						},
 					},
-				},
-				duressMode: notSupported,
-			}),
+					duressMode: notSupported,
+				}),
+				[Variant.MOBILE]: supported({
+					basicUnlock: {
+						ref: [
+							{
+								explanation:
+									'Opening the mobile app requires the phone to authenticate the user first.',
+								label: 'App unlock check in the mobile app source code',
+								url: 'https://github.com/rainbow-me/rainbow/blob/e3df13be2e139357770c4dd20573fc96836bd1ee/src/features/local-auth/isAuthenticated.ts#L16-L33',
+							},
+							{
+								explanation:
+									'That authentication is Face ID or Touch ID on iOS and fingerprint or face unlock on Android, with the phone passcode accepted in their place.',
+								label: 'Biometric unlock settings in the mobile app source code',
+								url: 'https://github.com/rainbow-me/rainbow/blob/e3df13be2e139357770c4dd20573fc96836bd1ee/src/features/local-auth/keychain.ts#L399-L414',
+							},
+							{
+								explanation:
+									'On an Android phone with no screen lock set, the app asks for a PIN of its own.',
+								label: 'PIN screen in the mobile app source code',
+								url: 'https://github.com/rainbow-me/rainbow/blob/e3df13be2e139357770c4dd20573fc96836bd1ee/src/features/local-auth/pinAuthentication.ts#L116-L123',
+							},
+						],
+						mechanisms: {
+							[BasicUnlockMechanism.PIN]: true,
+							[BasicUnlockMechanism.PASSWORD]: false,
+							[BasicUnlockMechanism.BIOMETRIC]: true,
+							[BasicUnlockMechanism.PATTERN]: false,
+						},
+					},
+					duressMode: notSupported,
+				}),
+			},
 			hardwareWalletSupport: {
 				ref: refTodo,
 				wallets: {

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -766,8 +766,7 @@ export const rainbow: SoftwareWallet = {
 								url: 'https://github.com/rainbow-me/rainbow/blob/e3df13be2e139357770c4dd20573fc96836bd1ee/src/features/local-auth/keychain.ts#L399-L414',
 							},
 							{
-								explanation:
-									'On an Android phone with no screen lock set, the app asks for a PIN of its own.',
+								explanation: 'On an Android phone with no screen lock set, the app asks for a PIN.',
 								label: 'PIN screen in the mobile app source code',
 								url: 'https://github.com/rainbow-me/rainbow/blob/e3df13be2e139357770c4dd20573fc96836bd1ee/src/features/local-auth/pinAuthentication.ts#L116-L123',
 							},


### PR DESCRIPTION
`security.duressResistance` recorded Rainbow as password-only with `ref: refTodo`, which is the browser extension's mechanism, not the mobile app's. 

Split per variant, each with source references:

- **Mobile** — biometric and PIN. `isAuthenticated()` gates the app on device authentication; `getPrivateAccessControlOptions()` sets `ACCESS_CONTROL.USER_PRESENCE` on iOS and `BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE` on Android; `shouldAuthenticateWithPIN()` routes to the app's own PIN screen on Android devices with no passcode set.
- **Browser** — password, unchanged in value, now referenced to the extension's unlock screen.

Separately this attribute exempts browser/desktop/embedded wallets. However, there are many wrench attacks that are home invasions in that case I think all of those wallets would be in play

🤖 Generated with [Claude Code](https://claude.com/claude-code)