### PR TITLE
Prevent redundant Check workflow runs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,35 +10,20 @@ on:
     types:
       - opened
       - reopened
-      - edited # Filtered down to base-branch changes; see `check-quick`.
       - synchronize
       - ready_for_review
       - review_requested
 
 # Supersede in-flight runs for the same PR (or the same branch, for pushes),
-# but never cancel a run on the trunk. Runs that `check-quick` is going to
-# skip are placed in a separate group, so that they cannot evict a run that
-# is doing real work and leave only a skipped -- and therefore passing --
-# result behind.
+# but never cancel a run on the trunk.
 concurrency:
-  group: >-
-    check-${{ github.event.pull_request.number || github.ref }}-${{
-    (github.event.action == 'edited' && github.event.changes.base == null)
-    && 'noop' || 'work' }}
+  group: check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/beta' }}
 
 jobs:
   check-quick:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    # `edited` fires for title, body and base-branch changes alike, and GitHub
-    # offers no way to subscribe to only the last one. Title and body edits
-    # cannot affect the result of any check here, so skip those runs; a
-    # base-branch change alters the merge commit under test, so keep those.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.action != 'edited' ||
-      github.event.changes.base != null
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,20 +1,38 @@
 name: Check
 
 on:
-  push: {}
+  push:
+    # Pushes to PR branches are already covered by the `synchronize` event
+    # below; only the trunk needs its own push trigger.
+    branches:
+      - beta
   pull_request:
     types:
       - opened
       - reopened
-      - edited
+      - edited # Filtered down to base-branch changes; see `check-quick`.
       - synchronize
       - ready_for_review
       - review_requested
+
+# Supersede in-flight runs for the same PR (or the same branch, for pushes),
+# but never cancel a run on the trunk.
+concurrency:
+  group: check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/beta' }}
 
 jobs:
   check-quick:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    # `edited` fires for title, body and base-branch changes alike, and GitHub
+    # offers no way to subscribe to only the last one. Title and body edits
+    # cannot affect the result of any check here, so skip those runs; a
+    # base-branch change alters the merge commit under test, so keep those.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'edited' ||
+      github.event.changes.base != null
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,9 +16,15 @@ on:
       - review_requested
 
 # Supersede in-flight runs for the same PR (or the same branch, for pushes),
-# but never cancel a run on the trunk.
+# but never cancel a run on the trunk. Runs that `check-quick` is going to
+# skip are placed in a separate group, so that they cannot evict a run that
+# is doing real work and leave only a skipped -- and therefore passing --
+# result behind.
 concurrency:
-  group: check-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    check-${{ github.event.pull_request.number || github.ref }}-${{
+    (github.event.action == 'edited' && github.event.changes.base == null)
+    && 'noop' || 'work' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/beta' }}
 
 jobs:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,14 +11,12 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
-      - review_requested
 
-# Supersede in-flight runs for the same PR (or the same branch, for pushes),
-# but never cancel a run on the trunk.
+# Supersede in-flight runs for the same PR. Give every trunk commit its own
+# group so that each one receives a recorded result.
 concurrency:
-  group: check-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/beta' }}
+  group: check-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check-quick:


### PR DESCRIPTION
## Issue

- Pushes to open PR branches ran CI twice: once for `push`, once for `pull_request.synchronize`.
- PR metadata and status changes (`edited`, `ready_for_review`, and `review_requested`) reran CI without changing the code under test.
- Superseded PR runs continued consuming CI resources.

Example runs triggered by editing PR title / body:
<img width="979" height="596" alt="ci-redundant-runs" src="https://github.com/user-attachments/assets/7d653e1f-20d6-4753-8843-c3380c94370d" />


## Suggested Changes

- Run `push` checks only for `beta`; PR branches remain covered by `pull_request`.
- Trigger PR checks only for `opened`, `reopened`, and `synchronize`.
- Cancel superseded runs for the same PR.
- Give each `beta` commit its own concurrency group so every trunk commit receives a result.

Removing metadata and status triggers aligns CI with its purpose: run checks when the tested state changes, not when PR metadata or review status changes. Rebases, force-pushes, and new commits still trigger `synchronize`.

## Caveat: base-branch retargeting

- Manually changing the PR base branch no longer triggers CI automatically.
- GitHub exposes base changes through the broad `edited` event, which also fires for title and body edits. Supporting only base changes would require extra job filtering plus special concurrency and check-name handling so metadata edits cannot cancel or mask real checks.
- If  changing the PR’s target branch, close and reopen the PR to run CI against the new target.