### PR TITLE
Schema: Clarify that reproducible builds must be independently reproducible

### DIFF
--- a/resources/docs/features/features.md
+++ b/resources/docs/features/features.md
@@ -3992,7 +3992,7 @@ type HasPublicChangelog = Support<MustRef<{}>>
 
 ### Type: `ReproducibleBuilds`
 
-Whether the wallet's release builds are reproducible, i.e. the same source revision and target can be rebuilt to produce bit-for-bit identical artifacts.
+Whether the wallet's release builds are reproducible, i.e. the same source revision and target can be rebuilt to produce bit-for-bit identical artifacts by an independent third party.
 
 ```typescript
 type ReproducibleBuilds = Support<WithRef<{}>>

--- a/resources/docs/features/features.md
+++ b/resources/docs/features/features.md
@@ -3992,7 +3992,7 @@ type HasPublicChangelog = Support<MustRef<{}>>
 
 ### Type: `ReproducibleBuilds`
 
-Whether the wallet's release builds are reproducible, i.e. the same source revision and target can be rebuilt to produce bit-for-bit identical artifacts by an independent third party.
+Whether the wallet's release builds are reproducible, i.e. the same source revision and target can be rebuilt to produce bit-for-bit identical artifacts by an independent party.
 
 ```typescript
 type ReproducibleBuilds = Support<WithRef<{}>>

--- a/src/schema/features/transparency/release-transparency.ts
+++ b/src/schema/features/transparency/release-transparency.ts
@@ -10,7 +10,7 @@ export type HasPublicChangelog = Support<MustRef<{}>>
 /**
  * Whether the wallet's release builds are reproducible, i.e. the same source
  * revision and target can be rebuilt to produce bit-for-bit identical artifacts
- * by an independent third party.
+ * by an independent party.
  */
 export type ReproducibleBuilds = Support<WithRef<{}>>
 

--- a/src/schema/features/transparency/release-transparency.ts
+++ b/src/schema/features/transparency/release-transparency.ts
@@ -9,7 +9,8 @@ export type HasPublicChangelog = Support<MustRef<{}>>
 
 /**
  * Whether the wallet's release builds are reproducible, i.e. the same source
- * revision and target can be rebuilt to produce bit-for-bit identical artifacts.
+ * revision and target can be rebuilt to produce bit-for-bit identical artifacts
+ * by an independent third party.
  */
 export type ReproducibleBuilds = Support<WithRef<{}>>
 


### PR DESCRIPTION
Follow-up to #1136.

Editing the TSDoc as discussed 