### PR TITLE
Governance: Mark the 2026-08 ESP application as submitted

### DIFF
--- a/governance/grants/2026-08-ethereum-foundation-esp-grant-proposal/proposal.md
+++ b/governance/grants/2026-08-ethereum-foundation-esp-grant-proposal/proposal.md
@@ -1,11 +1,12 @@
 ---
 title: Walletbeat 2026 EF ESP grant application
-description: 'Ethereum Foundation ESP direct grant application for Walletbeat, prepared in August 2026.'
-Status: Not yet submitted
+description: 'Ethereum Foundation ESP direct grant application for Walletbeat, submitted in August 2026.'
+Status: Submitted
 Grant-recipient: Walletbeat (collective)
 Amount: 90000
 Currency: USD
 Application-form: https://esp.ethereum.foundation/form-direct/apply
+Submission-date: 2026-08-26
 ---
 
 # Walletbeat 2026 EF ESP grant application

--- a/governance/grants/2026-08-ethereum-foundation-esp-grant-proposal/proposal.md
+++ b/governance/grants/2026-08-ethereum-foundation-esp-grant-proposal/proposal.md
@@ -6,7 +6,7 @@ Grant-recipient: Walletbeat (collective)
 Amount: 90000
 Currency: USD
 Application-form: https://esp.ethereum.foundation/form-direct/apply
-Submission-date: 2026-08-26
+Submission-date: 2026-08-27
 ---
 
 # Walletbeat 2026 EF ESP grant application


### PR DESCRIPTION
The application was submitted through the ESP direct grant form on 2026-08-26.

- `Status`: Not yet submitted -> Submitted
- Restores `Submission-date`
- Description now says submitted rather than prepared

Body text is unchanged.