### PR TITLE
Docs: Note that bare YYYY-MM-DD dates are UTC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Each attribute evaluates wallet features and returns one of 5 ratings:
 - Attributes evaluate only feature data, no other inputs.
 - Some feature blobs allow per-field unknowns while `/data` is incomplete. For those, keep the exported feature type as the complete shape `F`, put `Nullable<F>` only on the `WalletBaseFeatures` field, and let `ResolvedFeatures` expose either a full `F` or `null`. In `resolveFeatures`, wrap these entries with `nullable()` so any remaining `null` property makes the whole resolved feature `null`; for `Support`-wrapped blobs, put `Nullable` inside the supported payload and resolve with `nullable<Support<ResolvedShape>>(...)`. See `.cursor/rules/50-wallet-schema.mdc` for the full pattern.
 - Read `resources/docs/features/features.md` if you need to understand wallet feature types.
+- Bare `YYYY-MM-DD` dates are UTC, matching the treasury and wallet-data-collection tooling.
 
 ### Code quality
 


### PR DESCRIPTION
The convention already holds in the treasury and wallet-data-collection tooling, but was written down nowhere. Adding it to AGENTS.md so agents can find it.