### PR TITLE
MetaMask: Cite the source of the public revenue breakdown

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -430,6 +430,7 @@
 		"P256Verifier",
 		"pandoc",
 		"panopticon",
+		"ParaFi",
 		"Pashov",
 		"passcode",
 		"passworder",

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -278,7 +278,7 @@ export const metamask: SoftwareWallet = {
 			ref: [
 				{
 					explanation:
-						"DeFiLlama publishes MetaMask's fee and revenue figures, broken down by product line (wallet swaps, perpetuals, predictions and MetaMask USD) and by chain, with 24-hour, 30-day and all-time totals.",
+						"DeFiLlama publishes MetaMask's fee and revenue figures, broken down by product line (wallet swaps, perpetuals, predictions and MetaMask USD) and by chain.",
 					url: 'https://defillama.com/protocol/fees/metamask',
 				},
 				{

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -278,8 +278,21 @@ export const metamask: SoftwareWallet = {
 			ref: [
 				{
 					explanation:
-						'MetaMask is funded through transparent swap fees and venture capital with publicly disclosed funding rounds.',
+						"DeFiLlama publishes MetaMask's fee and revenue figures, broken down by product line (wallet swaps, perpetuals, predictions and MetaMask USD) and by chain, with 24-hour, 30-day and all-time totals.",
+					url: 'https://defillama.com/protocol/fees/metamask',
+				},
+				{
+					explanation:
+						'Consensys, which develops MetaMask, raised a $450 million Series D round led by ParaFi Capital in March 2022.',
+					label: 'Consensys Raises $450M Series D Funding',
 					url: 'https://consensys.io/blog/consensys-raises-450m-series-d-funding',
+				},
+				{
+					explanation:
+						'MetaMask discloses a 0.875% fee on its built-in swaps as a percentage via the Rate info tooltip.',
+					file: 'public/references/wallets/metamask/screenshots/2026-07-27-metamask-swap-rate.png',
+					label:
+						'MetaMask swap confirmation screen showing the 0.875% MetaMask fee disclosed via the Rate info tooltip',
 				},
 			],
 			revenueBreakdownIsPublic: true,


### PR DESCRIPTION
Adds references for MetaMask's monetization data. Revenue breakdown was true previously with no ref profided