### PR TITLE
Content: Add revoke cash exploits page to refs

### DIFF
--- a/src/schema/attributes/security/scam-prevention.ts
+++ b/src/schema/attributes/security/scam-prevention.ts
@@ -371,7 +371,7 @@ export const scamPrevention: Attribute<ScamPreventionMetadata> = {
 	},
 	question: sentence('Does the wallet warn the user about potential scams?'),
 	why: markdown(
-		'Transactions in Ethereum are very difficult to reverse, and there is no shortage of scams. Wallets have a role to play in helping users avoid known scams ahead of the user making the transaction.',
+		'Transactions in Ethereum are very difficult to reverse, and there is no shortage of scams. Wallets have a role to play in helping users avoid known scams ahead of the user making the transaction. This is especially true for unlimited token approvals: if the approved contract is later exploited, attackers can use that approval to drain the funds a user approved, a class of exploit that has [stolen over $362M since 2020](https://revoke.cash/exploits).',
 	),
 	methodology: markdown(`
 		Wallets are rated based on whether they alert the user about potential

--- a/src/schema/attributes/self-sovereignty/permissions-management.ts
+++ b/src/schema/attributes/self-sovereignty/permissions-management.ts
@@ -150,6 +150,9 @@ export const permissionsManagement: Attribute = {
 		permission to spend tokens on your behalf.
 		Malicious or compromised contracts with existing approvals can drain your wallet,
 		and approvals to other accounts carry the same risk.
+		[Over $362M has been stolen since 2020](https://revoke.cash/exploits) through such
+		approval hacks and exploits, where attackers use an existing approval to drain
+		the funds a user approved without directly compromising their wallet.
 
 		Being able to inspect and revoke approvals is an important tool for protecting
 		your assets from unnecessary or dangerous delegated spending authority.


### PR DESCRIPTION
Added a citation to [revoke.cash's exploits page](https://revoke.cash/exploits) in the `why` sections for `permissionsManagement` and `scamPrevention`, backing up the approval-hack risk with the $362M-stolen-since-2020 stat.
