### PR TITLE
Fix: Stage labels

### DIFF
--- a/src/utils/wallet-page-markdown.ts
+++ b/src/utils/wallet-page-markdown.ts
@@ -97,7 +97,7 @@ export function walletPageMarkdown<_AttributeGroupId extends string>(
 			for (let stageIndex = 0; stageIndex < ladderEvaluation.ladder.stages.length; stageIndex++) {
 				const s = ladderEvaluation.ladder.stages[stageIndex]
 
-				stageSection.push(`### Stage ${stageIndex}: ${s.label}`, '')
+				stageSection.push(`### ${s.label}`, '')
 
 				const { passedCount, totalCount } = computeCountsAndStatus(
 					allCriteriaInStage(s),

--- a/src/views/WalletAttributeSummary.svelte
+++ b/src/views/WalletAttributeSummary.svelte
@@ -81,6 +81,15 @@
 		||
 			undefined
 	)
+
+	const relevantStageLabels = $derived(
+		ladderEvaluation
+			? relevantStages
+				.map(stageIndex => ladderEvaluation.ladder.stages[stageIndex])
+				.filter(stage => stage !== undefined)
+				.map(stage => stage.label.replace(/^Stage /, ''))
+			: []
+	)
 </script>
 
 
@@ -102,13 +111,13 @@
 					<a
 						href={getWalletUrl(wallet, { variant, attributeAnchor: firstStage.id })}
 						data-link="camouflaged"
-						title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
+						title={`This attribute is required for stage${relevantStageLabels.length > 1 ? 's' : ''} ${relevantStageLabels.join(', ')}`}
 					>
 						<div
 							data-badge="small"
 							style:--accent="var(--accent-color)"
 						>
-							<small>Stage {relevantStages.join(', ')}</small>
+							<small>Stage {relevantStageLabels.join(', ')}</small>
 						</div>
 					</a>
 

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -983,18 +983,24 @@
 								{#if stageNumbers.length > 0}
 									{@const stageNumber = stageNumbers[0]}
 									{@const stage = ladderEvaluation?.ladder.stages[stageNumber]}
+									{@const stageLabels = ladderEvaluation ? (
+										stageNumbers
+											.map(n => ladderEvaluation.ladder.stages[n])
+											.filter(s => s !== undefined)
+											.map(s => s.label.replace(/^Stage /, ''))
+									) : []}
 
 									{#if stage}
 										<a
 											href={`#${stage.id}`}
 											data-link="camouflaged"
-											title={`This attribute is required for stage${stageNumbers.length > 1 ? 's' : ''} ${stageNumbers.join(', ')}`}
+											title={`This attribute is required for stage${stageLabels.length > 1 ? 's' : ''} ${stageLabels.join(', ')}`}
 										>
 											<div
 												data-badge="small"
 												style:--accent="var(--accent-color)"
 											>
-												<small>Stage {stageNumbers.join(', ')}</small>
+												<small>Stage {stageLabels.join(', ')}</small>
 											</div>
 										</a>
 									{/if}

--- a/tests/wallet-page-markdown.test.ts
+++ b/tests/wallet-page-markdown.test.ts
@@ -149,7 +149,7 @@ describe('walletPageMarkdown', () => {
 				const { stage, ladderEvaluation } = getWalletStageAndLadder(wallet)
 
 				if (typeof stage === 'object' && stage !== null && ladderEvaluation !== null) {
-					expect(md).toMatch(/### Stage \d+: /)
+					expect(md).toContain(`### ${stage.label}`)
 
 					const hasRatingIcon = /[✅❌➖❔]/.test(md)
 					const hasCriteriaPassed = /criteria passed/.test(md)

--- a/tests/wallet-page-markdown.test.ts
+++ b/tests/wallet-page-markdown.test.ts
@@ -149,7 +149,7 @@ describe('walletPageMarkdown', () => {
 				const { stage, ladderEvaluation } = getWalletStageAndLadder(wallet)
 
 				if (typeof stage === 'object' && stage !== null && ladderEvaluation !== null) {
-					expect(md).toContain(`### ${stage.label}`)
+					expect(md).toMatch(`### ${stage.label}`)
 
 					const hasRatingIcon = /[✅❌➖❔]/.test(md)
 					const hasCriteriaPassed = /criteria passed/.test(md)


### PR DESCRIPTION
# Fix: Stage labels

Stage badges and titles were showing raw stage numbers/indices instead of the actual stage label (e.g. `Stage 0` instead of the ladder's real label). Fixed by using `stage.label` (stripped of any leading `Stage ` prefix) in `WalletAttributeSummary.svelte`, `WalletPage.svelte`, and `wallet-page-markdown.ts`.


Saw that the .html.md file also has issues, duplicate stage label

<img width="788" height="700" alt="image" src="https://github.com/user-attachments/assets/629fe3a4-5ad5-4ebe-9e2b-531195cba8d8" />

Fixes #979