### PR TITLE
Security news: Update trezor's shipmonk data breach

### DIFF
--- a/data/news/2026-08-13-trezor-shipmonk-data-breach.ts
+++ b/data/news/2026-08-13-trezor-shipmonk-data-breach.ts
@@ -18,6 +18,10 @@ export default {
 			label: 'Trezor on X: Customer data exposure incident',
 			url: 'https://x.com/Trezor/status/2087885428313543059',
 		},
+		{
+			label: 'Trezor on X: ShipMonk breach affects more customers than originally thought',
+			url: 'https://x.com/Trezor/status/2095807665603584085',
+		},
 	],
 	impact: {
 		category: ImpactCategory.PRIVACY_LEAK,
@@ -25,10 +29,10 @@ export default {
 	},
 	publishedAt: '2026-08-13',
 	severity: Severity.HIGH,
-	status: IncidentStatus.MITIGATED,
+	status: IncidentStatus.ONGOING,
 	summary:
-		"ShipMonk, an independent shipping provider for Trezor, experienced a data breach that exposed customer personal information including full names, shipping addresses, phone numbers, and email addresses. 13,689 customers were affected, with exposure limited by Trezor's 90-day data retention policy. Trezor's own systems were not compromised and its devices remain secure, but affected customers may face an increase in phishing attempts and wrench attacks.",
+		"ShipMonk, an independent shipping provider for Trezor, experienced a data breach that exposed customer personal information including full names, shipping addresses, phone numbers, and email addresses. Trezor initially disclosed 13,689 affected customers, but a 2026-09-02 update revealed the breach was far larger: an additional 67,000 US customers who ordered between November 2019 and August 2021 had their full names, emails, phone numbers, shipping addresses, and order numbers exposed. Trezor said it had repeatedly obtained written assurance from ShipMonk that the data had been deleted per their contract, but it had not been. Trezor's own systems were not compromised and its devices remain secure, but affected customers may face an increase in phishing attempts and wrench attacks.",
 	title: 'Customer Data Exposed in Trezor Shipping Provider Incident',
-	updatedAt: '2026-08-13',
+	updatedAt: '2026-09-02',
 	wallets: ['trezor'],
 } as const satisfies WalletSecurityNews


### PR DESCRIPTION
Chore: Update trezor's shipmonk data breach

Trezor's update revealed the ShipMonk breach was far bigger than first disclosed, 67,000 additional US customers. 
_sigh_

__Apparently__, it's Shipmonk who leaked and not Trezor, but still