### PR TITLE
Fix Svelte generic diagnostics

### DIFF
--- a/src/views/WalletAttributeGroupSummary.svelte
+++ b/src/views/WalletAttributeGroupSummary.svelte
@@ -7,10 +7,9 @@
 
 
 <script lang="ts" generics="
-	_AttributeGroupId extends AttributeGroupId
+	_AttributeGroupId extends string
 ">
 	// Types/constants
-	import { AttributeGroupId } from '@/schema/attribute-tree'
 	import { calculateAttributeGroupScore, type AttributeGroup } from '@/schema/attribute-groups'
 	import type { RatedWallet } from '@/schema/wallet'
 	import { scoreToColor } from '@/utils/colors'

--- a/src/views/attributes/privacy/AddressCorrelationDetails.svelte
+++ b/src/views/attributes/privacy/AddressCorrelationDetails.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	// Types/constants
 	import type { WalletAddressLinkableBy } from '@/schema/attributes/privacy/address-correlation'
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 	import type { NonEmptyArray } from '@/types/utils/non-empty'
 	import { getWalletEvalStrings } from '@/utils/evaluation-content'
@@ -16,7 +16,7 @@
 		wallet,
 		linkables,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		linkables?: NonEmptyArray<WalletAddressLinkableBy> | undefined
 	} = $props()
 

--- a/src/views/attributes/privacy/PrivateTransfersDetails.svelte
+++ b/src/views/attributes/privacy/PrivateTransfersDetails.svelte
@@ -2,7 +2,7 @@
 	// Types/constants
 	import type { WalletNameStrings } from '@/schema/attributes'
 	import { PrivateTransferTechnology } from '@/schema/features/privacy/transaction-privacy'
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType, type MarkdownParagraph } from '@/types/content'
 
 	const technologyNames: Record<PrivateTransferTechnology, string> = {
@@ -18,7 +18,7 @@
 		wallet,
 		privateTransferDetails,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		privateTransferDetails: Map<PrivateTransferTechnology, {
 			sendingDetails: MarkdownParagraph<WalletNameStrings>
 			receivingDetails: MarkdownParagraph<WalletNameStrings>

--- a/src/views/attributes/security/AccountRecoveryDetails.svelte
+++ b/src/views/attributes/security/AccountRecoveryDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types/constants
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 	import { trimWhitespacePrefix } from '@/types/utils/text'
 	import type { AccountRecoveryMetadata } from '@/schema/attributes/security/account-recovery'
@@ -10,7 +10,7 @@
 		wallet,
 		metadata,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		metadata: AccountRecoveryMetadata
 	} = $props()
 

--- a/src/views/attributes/security/ChainVerificationDetails.svelte
+++ b/src/views/attributes/security/ChainVerificationDetails.svelte
@@ -3,7 +3,7 @@
 	import type { EthereumL1LightClient } from '@/schema/features/security/light-client'
 	import { ethereumL1LightClientUrl } from '@/schema/features/security/light-client'
 	import type { FullyQualifiedReference } from '@/schema/reference'
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 	import type { NonEmptyArray } from '@/types/utils/non-empty'
 	import { commaListPrefix } from '@/types/utils/text'
@@ -15,7 +15,7 @@
 		lightClients,
 		refs,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		lightClients?: NonEmptyArray<EthereumL1LightClient>
 		refs?: FullyQualifiedReference[]
 	} = $props()

--- a/src/views/attributes/security/ScamAlertDetails.svelte
+++ b/src/views/attributes/security/ScamAlertDetails.svelte
@@ -6,7 +6,7 @@
 	import type { Outcome } from '@/schema/attributes'
 	import { isSupported } from '@/schema/features/support'
 	import { toFullyQualified } from '@/schema/reference'
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 	import { commaListFormat } from '@/types/utils/text'
 	import { getWalletEvalStrings } from '@/utils/evaluation-content'
@@ -16,7 +16,7 @@
 		wallet,
 		outcome,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		outcome: Outcome<ScamPreventionMetadata>
 	} = $props()
 

--- a/src/views/attributes/security/SecurityAuditsDetails.svelte
+++ b/src/views/attributes/security/SecurityAuditsDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types/constants
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 	import { SecurityFlawSeverity } from '@/schema/features/security/security-audits'
 
@@ -51,7 +51,7 @@
 		hasUnaddressedFlaws,
 		bugBountyDetails,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		metadata: SecurityAuditsMetadata
 		auditedInLastYear?: boolean
 		hasUnaddressedFlaws?: boolean

--- a/src/views/attributes/self-sovereignty/AccountUnruggabilityDetails.svelte
+++ b/src/views/attributes/self-sovereignty/AccountUnruggabilityDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types/constants
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import type { AccountUnruggabilityMetadata } from '@/schema/attributes/self-sovereignty/account-unruggability'
 	import {
 		isAccountRecoverable,
@@ -14,7 +14,7 @@
 		wallet,
 		metadata,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		metadata: AccountUnruggabilityMetadata
 	} = $props()
 

--- a/src/views/attributes/self-sovereignty/TransactionInclusionDetails.svelte
+++ b/src/views/attributes/self-sovereignty/TransactionInclusionDetails.svelte
@@ -2,7 +2,7 @@
 	// Types/constants
 	import type { L1BroadcastSupport } from '@/schema/attributes/self-sovereignty/transaction-inclusion'
 	import type { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 
 
@@ -14,7 +14,7 @@
 		supportForceWithdrawal = [],
 		unsupportedL2s = [],
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		supportsL1Broadcast?: L1BroadcastSupport
 		supportAnyL2Transactions?: TransactionSubmissionL2Type[]
 		supportForceWithdrawal?: TransactionSubmissionL2Type[]

--- a/src/views/attributes/transparency/FundingDetails.svelte
+++ b/src/views/attributes/transparency/FundingDetails.svelte
@@ -6,7 +6,7 @@
 		monetizationStrategyName
 	} from '@/schema/features/transparency/monetization'
 	import { refs } from '@/schema/reference'
-	import type { RatedWallet } from '@/schema/wallet'
+	import type { WalletMetadata } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 
 
@@ -15,7 +15,7 @@
 		wallet,
 		monetization,
 	}: {
-		wallet: RatedWallet
+		wallet: { metadata: WalletMetadata }
 		monetization: Monetization | undefined
 	} = $props()
 


### PR DESCRIPTION
Part of #1178

## Summary

- narrow detail-component wallet props to the metadata they use
- align WalletAttributeGroupSummary with string-based attribute group IDs
- Removes 13 errors resulting in 45 errors and 26 warnings remaining