### PR TITLE
Show stage badges next to wallet titles on mobile

### DIFF
--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1578,6 +1578,16 @@
 							<a data-link="camouflaged" href={walletUrl}>{wallet.metadata.displayName}</a>
 						</h3>
 
+						{#if stage !== 'NOT_APPLICABLE' && stage !== null && ladderEvaluation !== null}
+							<span class="mobile-card-stage">
+								<WalletStageBadge
+									{stage}
+									{ladderEvaluation}
+									size="medium"
+								/>
+							</span>
+						{/if}
+
 						<div class="mobile-card-variants">
 							{#each cardSupportedVariants as variant}
 								<button
@@ -2060,6 +2070,7 @@
 	.mobile-name-and-variants {
 		display: flex;
 		align-items: center;
+		flex-wrap: wrap;
 		gap: 0.5rem;
 		flex: 1;
 		min-width: 0;
@@ -2077,6 +2088,10 @@
 			color: inherit;
 			text-decoration: none;
 		}
+	}
+
+	.mobile-card-stage {
+		flex-shrink: 0;
 	}
 
 	.mobile-card-variants {


### PR DESCRIPTION
## Summary
- Add the same `WalletStageBadge` used in the desktop comparison table next to each wallet title on mobile cards.
- The flower-chart center digit stays as a secondary cue; the badge makes the stage obvious.
- Hide the badge when stage rating is not applicable (e.g. hardware wallets).

Closes #1047