### PR TITLE
Attribute/duress resistance conditions

### DIFF
--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -7,7 +7,7 @@ import {
 } from '@/schema/features/ecosystem/hw-app-connection-support'
 import { HardwarePrivacyType } from '@/schema/features/privacy/hardware-privacy'
 import { HardwareWalletManufactureType, WalletProfile } from '@/schema/features/profile'
-import { BasicUnlockMechanism, DuressAction } from '@/schema/features/security/duress-resistance'
+import { BasicUnlockMechanism, BasicUnlockMechanismSupport, DuressAction } from '@/schema/features/security/duress-resistance'
 import { FirmwareType } from '@/schema/features/security/firmware'
 import {
 	KeyGenerationLocation,
@@ -148,10 +148,10 @@ export const keycardShell: HardwareWallet = {
 						'https://docs.keycard.tech/duress_pin',
 					],
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: true,
-						[BasicUnlockMechanism.PASSWORD]: false,
-						[BasicUnlockMechanism.BIOMETRIC]: false,
-						[BasicUnlockMechanism.PATTERN]: false,
+						[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.PASSWORD]: "NOT_SUPPORTED",
+						[BasicUnlockMechanism.BIOMETRIC]: "NOT_SUPPORTED",
+						[BasicUnlockMechanism.PATTERN]: "NOT_SUPPORTED",
 					},
 				},
 				duressMode: supported({

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -152,10 +152,12 @@ export const keycardShell: HardwareWallet = {
 						'https://docs.keycard.tech/duress_pin',
 					],
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PIN]: supported({
+							type: BasicUnlockMechanismSupport.REQUIRED,
+						}),
+						[BasicUnlockMechanism.PASSWORD]: notSupported,
+						[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+						[BasicUnlockMechanism.PATTERN]: notSupported,
 					},
 				},
 				duressMode: supported({

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -7,7 +7,11 @@ import {
 } from '@/schema/features/ecosystem/hw-app-connection-support'
 import { HardwarePrivacyType } from '@/schema/features/privacy/hardware-privacy'
 import { HardwareWalletManufactureType, WalletProfile } from '@/schema/features/profile'
-import { BasicUnlockMechanism, BasicUnlockMechanismSupport, DuressAction } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+	DuressAction,
+} from '@/schema/features/security/duress-resistance'
 import { FirmwareType } from '@/schema/features/security/firmware'
 import {
 	KeyGenerationLocation,
@@ -149,9 +153,9 @@ export const keycardShell: HardwareWallet = {
 					],
 					mechanisms: {
 						[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.PASSWORD]: "NOT_SUPPORTED",
-						[BasicUnlockMechanism.BIOMETRIC]: "NOT_SUPPORTED",
-						[BasicUnlockMechanism.PATTERN]: "NOT_SUPPORTED",
+						[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 					},
 				},
 				duressMode: supported({

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -746,10 +746,12 @@ export const ambire: SoftwareWallet = {
 				basicUnlock: {
 					ref: refTodo,
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PIN]: notSupported,
+						[BasicUnlockMechanism.PASSWORD]: supported({
+							type: BasicUnlockMechanismSupport.REQUIRED,
+						}),
+						[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+						[BasicUnlockMechanism.PATTERN]: notSupported,
 					},
 				},
 				duressMode: notSupported,

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -25,7 +25,10 @@ import {
 	BugBountyProgramAvailability,
 	type BugBountyProgramImplementation,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -743,10 +746,10 @@ export const ambire: SoftwareWallet = {
 				basicUnlock: {
 					ref: refTodo,
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: false,
-						[BasicUnlockMechanism.PASSWORD]: true,
-						[BasicUnlockMechanism.BIOMETRIC]: false,
-						[BasicUnlockMechanism.PATTERN]: false,
+						[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 					},
 				},
 				duressMode: notSupported,

--- a/data/software-wallets/completed.tmpl.ts
+++ b/data/software-wallets/completed.tmpl.ts
@@ -53,7 +53,11 @@ import {
 	type BugBountyProgramSupport,
 	LegalProtectionType,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism, DuressAction } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+	DuressAction,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -603,10 +607,10 @@ export const completedTemplate: SoftwareWallet = {
 				basicUnlock: {
 					ref: refTodo,
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: false,
-						[BasicUnlockMechanism.PASSWORD]: true,
-						[BasicUnlockMechanism.BIOMETRIC]: true,
-						[BasicUnlockMechanism.PATTERN]: false,
+						[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.PATTERN]: BasicUnlockMechanismSupport.REQUIRED,
 					},
 				},
 				duressMode: supported({

--- a/data/software-wallets/completed.tmpl.ts
+++ b/data/software-wallets/completed.tmpl.ts
@@ -607,10 +607,18 @@ export const completedTemplate: SoftwareWallet = {
 				basicUnlock: {
 					ref: refTodo,
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.PATTERN]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.PIN]: supported({
+							type: BasicUnlockMechanismSupport.REQUIRED,
+						}),
+						[BasicUnlockMechanism.PASSWORD]: supported({
+							type: BasicUnlockMechanismSupport.REQUIRED,
+						}),
+						[BasicUnlockMechanism.BIOMETRIC]: supported({
+							type: BasicUnlockMechanismSupport.REQUIRED,
+						}),
+						[BasicUnlockMechanism.PATTERN]: supported({
+							type: BasicUnlockMechanismSupport.REQUIRED,
+						}),
 					},
 				},
 				duressMode: supported({

--- a/data/software-wallets/gemwallet.ts
+++ b/data/software-wallets/gemwallet.ts
@@ -301,10 +301,12 @@ export const gemwallet: SoftwareWallet = {
 						},
 					],
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
-						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PIN]: notSupported,
+						[BasicUnlockMechanism.PASSWORD]: notSupported,
+						[BasicUnlockMechanism.BIOMETRIC]: supported({
+							type: BasicUnlockMechanismSupport.OPTIONAL,
+						}),
+						[BasicUnlockMechanism.PATTERN]: notSupported,
 					},
 				},
 				duressMode: notSupported,

--- a/data/software-wallets/gemwallet.ts
+++ b/data/software-wallets/gemwallet.ts
@@ -9,7 +9,10 @@ import {
 	BugBountyProgramAvailability,
 	type BugBountyProgramImplementation,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	KeyGenerationLocation,
 	MultiPartyKeyReconstruction,
@@ -298,10 +301,10 @@ export const gemwallet: SoftwareWallet = {
 						},
 					],
 					mechanisms: {
-						[BasicUnlockMechanism.PIN]: false,
-						[BasicUnlockMechanism.PASSWORD]: false,
-						[BasicUnlockMechanism.BIOMETRIC]: true,
-						[BasicUnlockMechanism.PATTERN]: false,
+						[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
+						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 					},
 				},
 				duressMode: notSupported,

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -447,10 +447,12 @@ export const metamask: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,
@@ -466,10 +468,14 @@ export const metamask: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.BIOMETRIC]: supported({
+								type: BasicUnlockMechanismSupport.OPTIONAL,
+							}),
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -14,7 +14,10 @@ import {
 	BugBountyProgramAvailability,
 	LegalProtectionType,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -444,10 +447,10 @@ export const metamask: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: false,
-							[BasicUnlockMechanism.PASSWORD]: true,
-							[BasicUnlockMechanism.BIOMETRIC]: false,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 					},
 					duressMode: notSupported,
@@ -463,10 +466,10 @@ export const metamask: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: false,
-							[BasicUnlockMechanism.PASSWORD]: true,
-							[BasicUnlockMechanism.BIOMETRIC]: true,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -267,10 +267,12 @@ export const phantom: SoftwareWallet = {
 					basicUnlock: {
 						ref: refTodo,
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,
@@ -279,10 +281,12 @@ export const phantom: SoftwareWallet = {
 					basicUnlock: {
 						ref: refTodo,
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: notSupported,
+							[BasicUnlockMechanism.BIOMETRIC]: supported({
+								type: BasicUnlockMechanismSupport.OPTIONAL,
+							}),
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -10,7 +10,10 @@ import {
 	BugBountyProgramAvailability,
 	type BugBountyProgramImplementation,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -260,16 +263,30 @@ export const phantom: SoftwareWallet = {
 				upgradePathAvailable: true,
 			}),
 			duressResistance: {
-				basicUnlock: {
-					ref: refTodo,
-					mechanisms: {
-						[BasicUnlockMechanism.PIN]: false,
-						[BasicUnlockMechanism.PASSWORD]: false,
-						[BasicUnlockMechanism.BIOMETRIC]: true,
-						[BasicUnlockMechanism.PATTERN]: false,
+				[Variant.BROWSER]: {
+					basicUnlock: {
+						ref: refTodo,
+						mechanisms: {
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+						},
 					},
+					duressMode: notSupported,
 				},
-				duressMode: notSupported,
+				[Variant.MOBILE]: {
+					basicUnlock: {
+						ref: refTodo,
+						mechanisms: {
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+						},
+					},
+					duressMode: notSupported,
+				},
 			},
 			hardwareWalletSupport: {
 				ref: {

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -14,7 +14,10 @@ import {
 	BugBountyProgramAvailability,
 	type BugBountyProgramImplementation,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -385,10 +388,10 @@ export const rabby: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: false,
-							[BasicUnlockMechanism.PASSWORD]: true,
-							[BasicUnlockMechanism.BIOMETRIC]: true,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -388,10 +388,14 @@ export const rabby: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.BIOMETRIC]: supported({
+								type: BasicUnlockMechanismSupport.OPTIONAL,
+							}),
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -765,10 +765,12 @@ export const rainbow: SoftwareWallet = {
 							url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/unlock/index.tsx',
 						},
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,
@@ -795,10 +797,14 @@ export const rainbow: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.OPTIONAL,
-							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: supported({
+								type: BasicUnlockMechanismSupport.OPTIONAL,
+							}),
+							[BasicUnlockMechanism.PASSWORD]: notSupported,
+							[BasicUnlockMechanism.BIOMETRIC]: supported({
+								type: BasicUnlockMechanismSupport.OPTIONAL,
+							}),
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -18,7 +18,10 @@ import { CollectionPolicy } from '@/schema/features/privacy/data-collection'
 import { PrivateTransferTechnology } from '@/schema/features/privacy/transaction-privacy'
 import { WalletProfile } from '@/schema/features/profile'
 import { GuardianPolicyType, GuardianType } from '@/schema/features/security/account-recovery'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -754,7 +757,7 @@ export const rainbow: SoftwareWallet = {
 			},
 			bugBountyProgram: notSupported,
 			duressResistance: {
-				[Variant.BROWSER]: supported({
+				[Variant.BROWSER]: {
 					basicUnlock: {
 						ref: {
 							explanation: 'The extension is unlocked with a password.',
@@ -762,15 +765,15 @@ export const rainbow: SoftwareWallet = {
 							url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/unlock/index.tsx',
 						},
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: false,
-							[BasicUnlockMechanism.PASSWORD]: true,
-							[BasicUnlockMechanism.BIOMETRIC]: false,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 					},
 					duressMode: notSupported,
-				}),
-				[Variant.MOBILE]: supported({
+				},
+				[Variant.MOBILE]: {
 					basicUnlock: {
 						ref: [
 							{
@@ -792,14 +795,14 @@ export const rainbow: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: true,
-							[BasicUnlockMechanism.PASSWORD]: false,
-							[BasicUnlockMechanism.BIOMETRIC]: true,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.OPTIONAL,
+							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 					},
 					duressMode: notSupported,
-				}),
+				},
 			},
 			hardwareWalletSupport: {
 				[Variant.BROWSER]: {

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -15,7 +15,10 @@ import {
 	BugBountyProgramAvailability,
 	type BugBountyProgramImplementation,
 } from '@/schema/features/security/bug-bounty-program'
-import { BasicUnlockMechanism } from '@/schema/features/security/duress-resistance'
+import {
+	BasicUnlockMechanism,
+	BasicUnlockMechanismSupport,
+} from '@/schema/features/security/duress-resistance'
 import {
 	HardwareWalletConnection,
 	HardwareWalletType,
@@ -559,10 +562,10 @@ export const zerion: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: true,
-							[BasicUnlockMechanism.PASSWORD]: false,
-							[BasicUnlockMechanism.BIOMETRIC]: true,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 					},
 					duressMode: notSupported,

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -562,10 +562,14 @@ export const zerion: SoftwareWallet = {
 							},
 						],
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.OPTIONAL,
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.PASSWORD]: notSupported,
+							[BasicUnlockMechanism.BIOMETRIC]: supported({
+								type: BasicUnlockMechanismSupport.OPTIONAL,
+							}),
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 					},
 					duressMode: notSupported,

--- a/resources/docs/features/features.md
+++ b/resources/docs/features/features.md
@@ -2212,11 +2212,20 @@ Basic unlock mechanisms a wallet may use to prevent unauthorized access. This is
 
 ---
 
+### Enum: `BasicUnlockMechanismSupport`
+
+Whether a given unlock mechanism is supported, and if so, whether the wallet requires it or merely offers it as one of several optional choices.
+
+- `OPTIONAL` = `'OPTIONAL'`: The wallet supports this unlock mechanism as an optional choice.
+- `REQUIRED` = `'REQUIRED'`: The wallet requires this unlock mechanism to unlock the wallet.
+
+---
+
 ### Interface: `BasicUnlock`
 
 Information about how the wallet locks itself against unauthorized access.
 
-- `mechanisms` (`Record<BasicUnlockMechanism, boolean>`): Which unlock mechanisms the wallet supports. Set each mechanism to `true` if supported, `false` if not.
+- `mechanisms` (`Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | 'NOT_SUPPORTED'>`): Which unlock mechanisms the wallet supports, and whether each one is required or merely optional.
 
 ---
 

--- a/resources/docs/features/features.md
+++ b/resources/docs/features/features.md
@@ -2221,11 +2221,19 @@ Whether a given unlock mechanism is supported, and if so, whether the wallet req
 
 ---
 
+### Interface: `BasicUnlockMechanismData`
+
+Data about a supported unlock mechanism: whether it is required or optional.
+
+- `type` (`BasicUnlockMechanismSupport`): Whether the wallet requires this unlock mechanism, or merely offers it as an option.
+
+---
+
 ### Interface: `BasicUnlock`
 
 Information about how the wallet locks itself against unauthorized access.
 
-- `mechanisms` (`Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | 'NOT_SUPPORTED'>`): Which unlock mechanisms the wallet supports, and whether each one is required or merely optional.
+- `mechanisms` (`Record<BasicUnlockMechanism, Support<BasicUnlockMechanismData>>`): Which unlock mechanisms the wallet supports, and whether each one is required or merely optional.
 
 ---
 

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -10,6 +10,7 @@ import {
 	type BasicUnlock,
 	BasicUnlockMechanism,
 	basicUnlockMechanismName,
+	BasicUnlockMechanismSupport,
 	DuressAction,
 	duressActionDescription,
 	duressActionName,
@@ -87,7 +88,7 @@ function weakLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>)
 function basicLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>): Evaluation {
 	const mechNames = commaListFormat(
 		Object.keys(basicUnlock.mechanisms)
-			.filter(m => basicUnlock.mechanisms[m])
+			.filter(m => basicUnlock.mechanisms[m] !== 'NOT_SUPPORTED')
 			.map(basicUnlockMechanismName),
 	)
 
@@ -124,7 +125,7 @@ function hasDuressMode(
 ): Evaluation {
 	const mechNames = commaListFormat(
 		Object.keys(basicUnlock.mechanisms)
-			.filter(m => basicUnlock.mechanisms[m])
+			.filter(m => basicUnlock.mechanisms[m] !== 'NOT_SUPPORTED')
 			.map(basicUnlockMechanismName),
 	)
 	const activeActions = Object.keys(duressMode.actions).filter(a => duressMode.actions[a])
@@ -173,9 +174,10 @@ export const duressResistance: Attribute = {
 
 		Wallets can mitigate this threat by:
 
-		1. **Lock screen (basic)**: Requiring a PIN, password, or biometric before granting access.
-		   This protects against opportunistic thieves and buys time, but a determined coercer can
-		   watch you unlock it.
+		1. **Lock screen (basic)**: Requiring a PIN, password, or pattern before granting access.
+		   Biometrics (Face ID, fingerprint) may be offered as an optional convenience, but must
+		   not be the only option: an attacker can force a fingerprint or face scan, and devices
+		   without biometric hardware would otherwise be left with no lock at all.
 
 		2. **Duress mode (stronger)**: A separate duress PIN or passphrase that, when entered,
 		   either opens a decoy wallet (providing plausible deniability) or wipes the device and
@@ -199,10 +201,10 @@ export const duressResistance: Attribute = {
 					EvaluationContext.forTest(() => duressResistance),
 					{
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: true,
-							[BasicUnlockMechanism.PASSWORD]: false,
-							[BasicUnlockMechanism.BIOMETRIC]: false,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 						ref: refNotNecessary,
 					},
@@ -228,10 +230,10 @@ export const duressResistance: Attribute = {
 					EvaluationContext.forTest(() => duressResistance),
 					{
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: true,
-							[BasicUnlockMechanism.PASSWORD]: false,
-							[BasicUnlockMechanism.BIOMETRIC]: false,
-							[BasicUnlockMechanism.PATTERN]: false,
+							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
 						},
 						ref: refNotNecessary,
 					},

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -249,15 +249,18 @@ export const duressResistance: Attribute = {
 				mdParagraph(
 					'The wallet only offers a biometric unlock, with no PIN, password, or pattern required.',
 				),
-				weakLockOnly(EvaluationContext.forTest(() => duressResistance), {
-					mechanisms: {
-						[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-						[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.REQUIRED,
-						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+				weakLockOnly(
+					EvaluationContext.forTest(() => duressResistance),
+					{
+						mechanisms: {
+							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.REQUIRED,
+							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+						},
+						ref: refNotNecessary,
 					},
-					ref: refNotNecessary,
-				}),
+				),
 			),
 		],
 	},

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -41,6 +41,49 @@ function noLockScreen(ctx: EvaluationContext): Evaluation {
 	})
 }
 
+/**
+ * A biometric-only (or merely optional) lock is not duress-resistant: an
+ * attacker can force a fingerprint/face scan, and devices without biometric
+ * hardware may end up with no lock at all. At least one of PIN, password, or
+ * pattern must be REQUIRED for the lock screen to count.
+ */
+function hasRequiredNonBiometricMechanism(basicUnlock: WithRef<BasicUnlock>): boolean {
+	return (
+		basicUnlock.mechanisms[BasicUnlockMechanism.PIN] === BasicUnlockMechanismSupport.REQUIRED ||
+		basicUnlock.mechanisms[BasicUnlockMechanism.PASSWORD] ===
+			BasicUnlockMechanismSupport.REQUIRED ||
+		basicUnlock.mechanisms[BasicUnlockMechanism.PATTERN] === BasicUnlockMechanismSupport.REQUIRED
+	)
+}
+
+function weakLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>): Evaluation {
+	const mechNames = commaListFormat(
+		Object.keys(basicUnlock.mechanisms)
+			.filter(m => basicUnlock.mechanisms[m] !== 'NOT_SUPPORTED')
+			.map(basicUnlockMechanismName),
+	)
+
+	return ctx.build({
+		outcome: {
+			id: 'weak_lock_only',
+			rating: Rating.FAIL,
+			displayName: 'Biometric-only or optional lock',
+			shortExplanation: sentence(
+				`{{WALLET_NAME}}'s lock screen (${mechNames}) does not require a PIN, password, or pattern.`,
+			),
+		},
+		details: markdown(
+			`{{WALLET_NAME}} protects access with ${mechNames}, but does not require a PIN,
+			password, or pattern. A biometric-only or merely optional lock is not duress-resistant:
+			an attacker can force a fingerprint or face scan, and devices without biometric hardware
+			may end up with no lock at all.`,
+		),
+		howToImprove: paragraph(
+			'{{WALLET_NAME}} should require a PIN, password, or pattern to unlock the wallet, in addition to any optional biometric convenience unlock.',
+		),
+	})
+}
+
 function basicLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>): Evaluation {
 	const mechNames = commaListFormat(
 		Object.keys(basicUnlock.mechanisms)

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -176,7 +176,7 @@ export const duressResistance: Attribute = {
 
 		1. **Lock screen (basic)**: Requiring a PIN, password, or pattern before granting access.
 		   Biometrics (Face ID, fingerprint) may be offered as an optional convenience, but must
-		   not be the only option: an attacker can force a fingerprint or face scan, and devices
+		   not be the only option. An attacker can force a fingerprint or face scan, and devices
 		   without biometric hardware would otherwise be left with no lock at all.
 
 		2. **Duress mode (stronger)**: A separate duress PIN or passphrase that, when entered,

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -201,10 +201,12 @@ export const duressResistance: Attribute = {
 					EvaluationContext.forTest(() => duressResistance),
 					{
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.PASSWORD]: notSupported,
+							[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 						ref: refNotNecessary,
 					},
@@ -230,10 +232,12 @@ export const duressResistance: Attribute = {
 					EvaluationContext.forTest(() => duressResistance),
 					{
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.BIOMETRIC]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.PASSWORD]: notSupported,
+							[BasicUnlockMechanism.BIOMETRIC]: notSupported,
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 						ref: refNotNecessary,
 					},
@@ -253,10 +257,12 @@ export const duressResistance: Attribute = {
 					EvaluationContext.forTest(() => duressResistance),
 					{
 						mechanisms: {
-							[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
-							[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.REQUIRED,
-							[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+							[BasicUnlockMechanism.PIN]: notSupported,
+							[BasicUnlockMechanism.PASSWORD]: notSupported,
+							[BasicUnlockMechanism.BIOMETRIC]: supported({
+								type: BasicUnlockMechanismSupport.REQUIRED,
+							}),
+							[BasicUnlockMechanism.PATTERN]: notSupported,
 						},
 						ref: refNotNecessary,
 					},

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -277,6 +277,10 @@ export const duressResistance: Attribute = {
 
 		ctx.addRef(feature.basicUnlock)
 
+		if (!hasRequiredNonBiometricMechanism(feature.basicUnlock)) {
+			return weakLockOnly(ctx, feature.basicUnlock)
+		}
+
 		if (!isSupported(feature.duressMode)) {
 			return basicLockOnly(ctx, feature.basicUnlock)
 		}

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -60,7 +60,7 @@ function hasRequiredNonBiometricMechanism(basicUnlock: WithRef<BasicUnlock>): bo
 function weakLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>): Evaluation {
 	const mechNames = commaListFormat(
 		Object.keys(basicUnlock.mechanisms)
-			.filter(m => basicUnlock.mechanisms[m] !== 'NOT_SUPPORTED')
+			.filter(m => isSupported(basicUnlock.mechanisms[m]))
 			.map(basicUnlockMechanismName),
 	)
 
@@ -88,7 +88,7 @@ function weakLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>)
 function basicLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>): Evaluation {
 	const mechNames = commaListFormat(
 		Object.keys(basicUnlock.mechanisms)
-			.filter(m => basicUnlock.mechanisms[m] !== 'NOT_SUPPORTED')
+			.filter(m => isSupported(basicUnlock.mechanisms[m]))
 			.map(basicUnlockMechanismName),
 	)
 
@@ -125,7 +125,7 @@ function hasDuressMode(
 ): Evaluation {
 	const mechNames = commaListFormat(
 		Object.keys(basicUnlock.mechanisms)
-			.filter(m => basicUnlock.mechanisms[m] !== 'NOT_SUPPORTED')
+			.filter(m => isSupported(basicUnlock.mechanisms[m]))
 			.map(basicUnlockMechanismName),
 	)
 	const activeActions = Object.keys(duressMode.actions).filter(a => duressMode.actions[a])

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -79,12 +79,14 @@ function weakLockOnly(ctx: EvaluationContext, basicUnlock: WithRef<BasicUnlock>)
 		},
 		details: markdown(
 			`{{WALLET_NAME}} protects access with ${mechNames}, but does not require a PIN,
-			password, or pattern. A biometric-only or merely optional lock is not duress-resistant:
-			an attacker can force a fingerprint or face scan, and devices without biometric hardware
-			may end up with no lock at all.`,
+			password, or pattern. A biometric-only or merely optional lock offers no plausible
+			deniability. A forced PIN, password, or pattern entry leaves room for a decoy code
+			that unlocks a decoy wallet or wipes the device, indistinguishable to the attacker
+			from a genuine entry, and an attacker cannot tell a user who has forgotten their
+			credential from one who is only pretending to.`,
 		),
 		howToImprove: paragraph(
-			'{{WALLET_NAME}} should require a PIN, password, or pattern to unlock the wallet, in addition to any optional biometric convenience unlock.',
+			'{{WALLET_NAME}} should require a PIN, password, or pattern to unlock the wallet, in addition to any optional biometric convenience unlock. This keeps such entry methods normalized across wallets, preserving plausible deniability for wallets that support decoy codes.',
 		),
 	})
 }
@@ -180,8 +182,12 @@ export const duressResistance: Attribute = {
 
 		1. **Lock screen (basic)**: Requiring a PIN, password, or pattern before granting access.
 		   Biometrics (Face ID, fingerprint) may be offered as an optional convenience, but must
-		   not be the only option. An attacker can force a fingerprint or face scan, and devices
-		   without biometric hardware would otherwise be left with no lock at all.
+		   not be the only option, since they offer no plausible deniability. A forced
+		   PIN/password/pattern entry leaves room for a decoy code that unlocks a decoy wallet or
+		   wipes the device, indistinguishable to the attacker from a genuine entry, and an
+		   attacker cannot tell a user who has genuinely forgotten their credential from one who is
+		   only pretending to. Devices without biometric hardware would otherwise be left with no
+		   lock at all.
 
 		2. **Duress mode (stronger)**: A separate duress PIN or passphrase that, when entered,
 		   either opens a decoy wallet (providing plausible deniability) or wipes the device and

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -243,6 +243,20 @@ export const duressResistance: Attribute = {
 				mdParagraph('The wallet has no lock screen and is accessible to anyone who opens it.'),
 				noLockScreen(EvaluationContext.forTest(() => duressResistance)),
 			),
+			exampleRating(
+				mdParagraph(
+					'The wallet only offers a biometric unlock, with no PIN, password, or pattern required.',
+				),
+				weakLockOnly(EvaluationContext.forTest(() => duressResistance), {
+					mechanisms: {
+						[BasicUnlockMechanism.PIN]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.PASSWORD]: 'NOT_SUPPORTED',
+						[BasicUnlockMechanism.BIOMETRIC]: BasicUnlockMechanismSupport.REQUIRED,
+						[BasicUnlockMechanism.PATTERN]: 'NOT_SUPPORTED',
+					},
+					ref: refNotNecessary,
+				}),
+			),
 		],
 	},
 	aggregate: (perVariant: AtLeastOneVariant<Evaluation>) => pickWorstRating(perVariant),

--- a/src/schema/attributes/security/duress-resistance.ts
+++ b/src/schema/attributes/security/duress-resistance.ts
@@ -9,6 +9,7 @@ import {
 import {
 	type BasicUnlock,
 	BasicUnlockMechanism,
+	type BasicUnlockMechanismData,
 	basicUnlockMechanismName,
 	BasicUnlockMechanismSupport,
 	DuressAction,
@@ -16,7 +17,13 @@ import {
 	duressActionName,
 	type DuressMode,
 } from '@/schema/features/security/duress-resistance'
-import { isSupported, type Supported } from '@/schema/features/support'
+import {
+	isSupported,
+	notSupported,
+	type Support,
+	type Supported,
+	supported,
+} from '@/schema/features/support'
 import { refNotNecessary, type WithRef } from '@/schema/reference'
 import { type AtLeastOneVariant, Variant } from '@/schema/variants'
 import { verifiabilityRequiresAtLeastOneReference } from '@/schema/verifiability'
@@ -42,18 +49,15 @@ function noLockScreen(ctx: EvaluationContext): Evaluation {
 	})
 }
 
-/**
- * A biometric-only (or merely optional) lock is not duress-resistant: an
- * attacker can force a fingerprint/face scan, and devices without biometric
- * hardware may end up with no lock at all. At least one of PIN, password, or
- * pattern must be REQUIRED for the lock screen to count.
- */
+function isRequired(mechanism: Support<BasicUnlockMechanismData>): boolean {
+	return isSupported(mechanism) && mechanism.type === BasicUnlockMechanismSupport.REQUIRED
+}
+
 function hasRequiredNonBiometricMechanism(basicUnlock: WithRef<BasicUnlock>): boolean {
 	return (
-		basicUnlock.mechanisms[BasicUnlockMechanism.PIN] === BasicUnlockMechanismSupport.REQUIRED ||
-		basicUnlock.mechanisms[BasicUnlockMechanism.PASSWORD] ===
-			BasicUnlockMechanismSupport.REQUIRED ||
-		basicUnlock.mechanisms[BasicUnlockMechanism.PATTERN] === BasicUnlockMechanismSupport.REQUIRED
+		isRequired(basicUnlock.mechanisms[BasicUnlockMechanism.PIN]) ||
+		isRequired(basicUnlock.mechanisms[BasicUnlockMechanism.PASSWORD]) ||
+		isRequired(basicUnlock.mechanisms[BasicUnlockMechanism.PATTERN])
 	)
 }
 

--- a/src/schema/features/security/duress-resistance.ts
+++ b/src/schema/features/security/duress-resistance.ts
@@ -54,7 +54,7 @@ export interface BasicUnlock {
 	 * Which unlock mechanisms the wallet supports, and whether each one is
 	 * required or merely optional.
 	 */
-	mechanisms: Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | "NOT_SUPPORTED">
+	mechanisms: Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | 'NOT_SUPPORTED'>
 }
 
 /**

--- a/src/schema/features/security/duress-resistance.ts
+++ b/src/schema/features/security/duress-resistance.ts
@@ -35,14 +35,26 @@ export function basicUnlockMechanismName(m: BasicUnlockMechanism): string {
 }
 
 /**
+ * Whether a given unlock mechanism is supported, and if so, whether the
+ * wallet requires it or merely offers it as one of several optional choices.
+ */
+export enum BasicUnlockMechanismSupport {
+	/** The wallet supports this unlock mechanism as an optional choice. */
+	OPTIONAL = 'OPTIONAL',
+
+	/** The wallet requires this unlock mechanism to unlock the wallet. */
+	REQUIRED = 'REQUIRED',
+}
+
+/**
  * Information about how the wallet locks itself against unauthorized access.
  */
 export interface BasicUnlock {
 	/**
-	 * Which unlock mechanisms the wallet supports.
-	 * Set each mechanism to `true` if supported, `false` if not.
+	 * Which unlock mechanisms the wallet supports, and whether each one is
+	 * required or merely optional.
 	 */
-	mechanisms: Record<BasicUnlockMechanism, boolean>
+	mechanisms: Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | "NOT_SUPPORTED">
 }
 
 /**

--- a/src/schema/features/security/duress-resistance.ts
+++ b/src/schema/features/security/duress-resistance.ts
@@ -46,6 +46,12 @@ export enum BasicUnlockMechanismSupport {
 	REQUIRED = 'REQUIRED',
 }
 
+/** Data about a supported unlock mechanism: whether it is required or optional. */
+export interface BasicUnlockMechanismData {
+	/** Whether the wallet requires this unlock mechanism, or merely offers it as an option. */
+	type: BasicUnlockMechanismSupport
+}
+
 /**
  * Information about how the wallet locks itself against unauthorized access.
  */
@@ -54,7 +60,7 @@ export interface BasicUnlock {
 	 * Which unlock mechanisms the wallet supports, and whether each one is
 	 * required or merely optional.
 	 */
-	mechanisms: Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | 'NOT_SUPPORTED'>
+	mechanisms: Record<BasicUnlockMechanism, Support<BasicUnlockMechanismData>>
 }
 
 /**


### PR DESCRIPTION
Attribute: Require non-biometric unlock for duress resistance

## Changes

- Added `BasicUnlockMechanismSupport` enum (`OPTIONAL` / `REQUIRED`) to replace the old boolean `mechanisms` map, so a wallet can distinguish "supports PIN" from "requires PIN":

```ts
export enum BasicUnlockMechanismSupport {
	OPTIONAL = 'OPTIONAL',
	REQUIRED = 'REQUIRED',
}

export interface BasicUnlock {
	mechanisms: Record<BasicUnlockMechanism, BasicUnlockMechanismSupport | 'NOT_SUPPORTED'>
}
```

- A biometric-only or merely-optional lock is no longer duress-resistant. An attacker can force a fingerprint/face scan, and devices without biometric hardware can end up with no lock at all. `duress-resistance.ts` now requires at least one of PIN, password, or pattern to be `REQUIRED`, otherwise it fails with a new `weak_lock_only` outcome.

| Rating | Condition |
| --- | --- |
| **Pass** | Has a required PIN, password, or pattern lock, plus a working duress mode |
| **Partial** | Has a required PIN, password, or pattern lock, no duress mode |
| **Fail** | No lock screen, or only biometric/optional mechanisms with no required PIN/password/pattern |

## Other changes

- Updated wallets' duress resistance
- Regenerated `features.md`


Closes #1161