### PR TITLE
Fix clusters 2 & 3 for `svelte-check`

### DIFF
--- a/src/components/BlockTransition.svelte
+++ b/src/components/BlockTransition.svelte
@@ -7,8 +7,8 @@
 	import type { TransitionConfig } from 'svelte/transition'
 
 	type TransitionFn = {
-		bivarianceHack(node: Element, params?: unknown): TransitionConfig
-	}['bivarianceHack']
+		transition(node: Element, params?: unknown): TransitionConfig
+	}['transition']
 
 	type TransitionFnAndParams = [TransitionFn] | [TransitionFn, unknown]
 

--- a/src/components/BlockTransition.svelte
+++ b/src/components/BlockTransition.svelte
@@ -4,6 +4,13 @@
 ">
 	// Types
 	import type { Snippet } from 'svelte'
+	import type { TransitionConfig } from 'svelte/transition'
+
+	type TransitionFn = {
+		bivarianceHack(node: Element, params?: unknown): TransitionConfig
+	}['bivarianceHack']
+
+	type TransitionFnAndParams = [TransitionFn] | [TransitionFn, unknown]
 
 
 	// Props
@@ -17,6 +24,7 @@
 
 		// View options
 		align = 'top',
+		contentTransition = [fade, { duration: 200, easing: expoOut }],
 	}: {
 		key?: Key
 		value?: Value
@@ -27,6 +35,7 @@
 
 		// View options
 		align?: 'top' | 'center' | 'bottom'
+		contentTransition?: TransitionFnAndParams | { in?: TransitionFnAndParams, out?: TransitionFnAndParams }
 	} = $props()
 
 
@@ -57,21 +66,101 @@
 	data-stack
 	class={`align-${align}`}
 >
-	{#key key ?? value}
-		<div
-			data-content
-			bind:borderBoxSize
-			data-column
-			class={`align-${align}`}
-			transition:fade={{ duration: 200, easing: expoOut }}
-		>
-			{#if children}
-				{@render children({ key, value })}
-			{:else}
-				{value}
-			{/if}
-		</div>
-	{/key}
+	{#if contentTransition}
+		{#if 'in' in contentTransition && contentTransition.in && 'out' in contentTransition && contentTransition.out}
+			{@const { in: [inTransition, inParams], out: [outTransition, outParams] } = contentTransition}
+
+			{#key key ?? value}
+				<div
+					data-content
+					bind:borderBoxSize
+					data-column
+					class={`align-${align}`}
+					in:inTransition={inParams}
+					out:outTransition={outParams}
+				>
+					{#if children}
+						{@render children({ key, value })}
+					{:else}
+						{value}
+					{/if}
+				</div>
+			{/key}
+
+		{:else if 'in' in contentTransition && contentTransition.in}
+			{@const { in: [inTransition, inParams] } = contentTransition}
+
+			{#key key ?? value}
+				<div
+					data-content
+					bind:borderBoxSize
+					data-column
+					class={`align-${align}`}
+					in:inTransition={inParams}
+				>
+					{#if children}
+						{@render children({ key, value })}
+					{:else}
+						{value}
+					{/if}
+				</div>
+			{/key}
+
+		{:else if 'out' in contentTransition && contentTransition.out}
+			{@const { out: [outTransition, outParams] } = contentTransition}
+
+			{#key key ?? value}
+				<div
+					data-content
+					bind:borderBoxSize
+					data-column
+					class={`align-${align}`}
+					out:outTransition={outParams}
+				>
+					{#if children}
+						{@render children({ key, value })}
+					{:else}
+						{value}
+					{/if}
+				</div>
+			{/key}
+
+		{:else if Array.isArray(contentTransition)}
+			{@const [transition, transitionParams] = contentTransition}
+
+			{#key key ?? value}
+				<div
+					data-content
+					bind:borderBoxSize
+					data-column
+					class={`align-${align}`}
+					transition:transition={transitionParams}
+				>
+					{#if children}
+						{@render children({ key, value })}
+					{:else}
+						{value}
+					{/if}
+				</div>
+			{/key}
+		{/if}
+
+	{:else}
+		{#key key ?? value}
+			<div
+				data-content
+				bind:borderBoxSize
+				data-column
+				class={`align-${align}`}
+			>
+				{#if children}
+					{@render children({ key, value })}
+				{:else}
+					{value}
+				{/if}
+			</div>
+		{/key}
+	{/if}
 </div>
 
 

--- a/src/components/BlockTransition.svelte
+++ b/src/components/BlockTransition.svelte
@@ -4,15 +4,6 @@
 ">
 	// Types
 	import type { Snippet } from 'svelte'
-	import type { TransitionConfig } from 'svelte/transition'
-
-	type TransitionFnAndParams<
-		Fn extends (node: Element, _?: unknown) => TransitionConfig = (node: Element, _?: unknown) => TransitionConfig
-	> = (
-		Fn extends (node: Element, _?: infer Params) => TransitionConfig
-			? [Fn] | [Fn, Params | undefined]
-			: never
-	)
 
 
 	// Props
@@ -26,7 +17,6 @@
 
 		// View options
 		align = 'top',
-		contentTransition = [fade, { duration: 200, easing: expoOut }],
 	}: {
 		key?: Key
 		value?: Value
@@ -37,7 +27,6 @@
 
 		// View options
 		align?: 'top' | 'center' | 'bottom'
-		contentTransition?: TransitionFnAndParams | { in?: TransitionFnAndParams, out?: TransitionFnAndParams }
 	} = $props()
 
 
@@ -68,101 +57,21 @@
 	data-stack
 	class={`align-${align}`}
 >
-	{#if contentTransition}
-		{#if 'in' in contentTransition && contentTransition.in && 'out' in contentTransition && contentTransition.out}
-			{@const { in: [inTransition, inParams], out: [outTransition, outParams] } = contentTransition}
-
-			{#key key ?? value}
-				<div
-					data-content
-					bind:borderBoxSize
-					data-column
-					class={`align-${align}`}
-					in:inTransition={inParams}
-					out:outTransition={outParams}
-				>
-					{#if children}
-						{@render children({ key, value })}
-					{:else}
-						{value}
-					{/if}
-				</div>
-			{/key}
-
-		{:else if 'in' in contentTransition && contentTransition.in}
-			{@const { in: [inTransition, inParams] } = contentTransition}
-
-			{#key key ?? value}
-				<div
-					data-content
-					bind:borderBoxSize
-					data-column
-					class={`align-${align}`}
-					in:inTransition={inParams}
-				>
-					{#if children}
-						{@render children({ key, value })}
-					{:else}
-						{value}
-					{/if}
-				</div>
-			{/key}
-
-		{:else if 'out' in contentTransition && contentTransition.out}
-			{@const { out: [outTransition, outParams] } = contentTransition}
-
-			{#key key ?? value}
-				<div
-					data-content
-					bind:borderBoxSize
-					data-column
-					class={`align-${align}`}
-					out:outTransition={outParams}
-				>
-					{#if children}
-						{@render children({ key, value })}
-					{:else}
-						{value}
-					{/if}
-				</div>
-			{/key}
-
-		{:else if Array.isArray(contentTransition)}
-			{@const [transition, transitionParams] = contentTransition}
-
-			{#key key ?? value}
-				<div
-					data-content
-					bind:borderBoxSize
-					data-column
-					class={`align-${align}`}
-					transition:transition={transitionParams}
-				>
-					{#if children}
-						{@render children({ key, value })}
-					{:else}
-						{value}
-					{/if}
-				</div>
-			{/key}
-		{/if}
-
-	{:else}
-		{#key key ?? value}
-			<div
-				data-content
-				bind:borderBoxSize
-				data-column
-				class={`align-${align}`}
-			>
-				{#if children}
-					{@render children({ key, value })}
-				{:else}
-					{value}
-				{/if}
-			</div>
-		{/key}
-	{/if}
+	{#key key ?? value}
+		<div
+			data-content
+			bind:borderBoxSize
+			data-column
+			class={`align-${align}`}
+			transition:fade={{ duration: 200, easing: expoOut }}
+		>
+			{#if children}
+				{@render children({ key, value })}
+			{:else}
+				{value}
+			{/if}
+		</div>
+	{/key}
 </div>
 
 

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -96,12 +96,15 @@
 
 	// Functions
 	const sliceFill = (slice: ComputedSlice) => {
-		if (!slice.children?.length || !slice.gradient) return slice.color
+		const children = slice.children
+		const gradient = slice.gradient
 
-		const colorWeights = slice.gradient.colors
+		if (!children?.length || !gradient) return slice.color
+
+		const colorWeights = gradient.colors
 			.map(color => ({
 				color,
-				weight: slice.children
+				weight: children
 					.filter(child => child.color === color)
 					.reduce((sum, child) => sum + child.weight, 0),
 			}))
@@ -110,10 +113,10 @@
 		if (colorWeights.length <= 1) {
 			const color = colorWeights[0]?.color ?? slice.color
 
-			return color === slice.gradient.transparentStopColor ? 'var(--rating-unrated)' : color
+			return color === gradient.transparentStopColor ? 'var(--rating-unrated)' : color
 		}
 
-		const areaRadiusStops = slice.gradient.areaRadiusStops
+		const areaRadiusStops = gradient.areaRadiusStops
 		const totalWeight = colorWeights.reduce((sum, entry) => sum + entry.weight, 0)
 		const minimumStopGap = Math.min(8, (slice.computed.outerR - slice.computed.innerR) / Math.max(colorWeights.length - 1, 1))
 		const stopPositions = colorWeights
@@ -155,7 +158,7 @@
 				[],
 			)
 
-		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === slice.gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')}), var(--rating-unrated)`
+		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')}), var(--rating-unrated)`
 	}
 
 	const sliceBackdropFilter = (slice: ComputedSlice) => (

--- a/src/components/Tabs/AppIsolationTab.svelte
+++ b/src/components/Tabs/AppIsolationTab.svelte
@@ -17,7 +17,11 @@
 		error: '',
 	})
 
-	const walletConnectState = $state({
+	const walletConnectState = $state<{
+		isPending: boolean
+		result: unknown
+		error: string
+	}>({
 		isPending: false,
 		result: null,
 		error: '',

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -23,7 +23,7 @@ export type WalletNameAndPseudonymStrings =
  * Used as return type of getWalletEvalStrings so it's assignable to Typography's
  * strings prop when content uses WalletNameAndPseudonymStrings (which is a union including null).
  */
-export interface ConcreteWalletEvalStrings {
+export type ConcreteWalletEvalStrings = {
 	WALLET_NAME: string
 	WALLET_PSEUDONYM_SINGULAR: string
 	WALLET_PSEUDONYM_PLURAL: string

--- a/src/schema/stages.ts
+++ b/src/schema/stages.ts
@@ -95,7 +95,7 @@ export type StageCriterionEvaluation = {
 } & (
 	| {
 			// If not unrated, the explanation must be provided.
-			rating: Omit<StageCriterionRating, StageCriterionRating.UNRATED>
+			rating: Exclude<StageCriterionRating, StageCriterionRating.UNRATED>
 
 			/** Explanation of the rating. */
 			explanation: Sentence<WalletNameStrings>

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -306,7 +306,13 @@
 	const attrToRelevantVariants = $derived.by(() => {
 		const map = new Map<string, Variant[]>()
 
-		for (const [variant, variantSpecificityMap] of Object.entries(wallet.variantSpecificity)) {
+		for (const entry of Object.entries(wallet.variantSpecificity)) {
+			if (!entry) continue
+
+			const [variant, variantSpecificityMap] = entry
+
+			if (!variantSpecificityMap) continue
+
 			for (const [evalAttrId, variantSpecificity] of variantSpecificityMap) {
 				switch (variantSpecificity) {
 					case VariantSpecificity.ALL_SAME:

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -825,7 +825,7 @@
 						</div>
 					{/if}
 				{:else if column.id === 'displayName'}
-					{@const displayName = value}
+					{@const displayName = wallet.metadata.displayName}
 					{@const accountTypes = walletSupportedAccountTypes(wallet, selectedVariant ?? 'ALL_VARIANTS')}
 					{@const supportedVariants = (
 						[Variant.BROWSER, Variant.MOBILE, Variant.DESKTOP, Variant.EMBEDDED, Variant.HARDWARE]

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -948,7 +948,7 @@
 													[]
 											),
 										]
-											.filter(Boolean)
+											.filter(tag => tag !== false && tag !== undefined)
 									) as tag (tag.label)}
 										<button
 											data-tag={tag.type}


### PR DESCRIPTION
Part of #1178.

- Fix TypeScript inference edges
- Fix control-flow narrowing and nullability
- Reduce `check:svelte` errors from 45 to 21