### PR TITLE
Fix Svelte UI component contract drift

### DIFF
--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -199,11 +199,10 @@
 		href={slice.href}
 
 		class="slice"
-		title={slice.titleText}
 
 		role="button"
 		tabindex="0"
-		aria-label={slice.titleText}
+		aria-label={slice.ariaLabel}
 		onmouseenter={() => { onSliceMouseEnter?.(slice.id) }}
 		onmouseleave={() => { onSliceMouseLeave?.(slice.id) }}
 		onfocus={() => { onSliceFocus?.(slice.id) }}

--- a/src/components/pie-geometry.ts
+++ b/src/components/pie-geometry.ts
@@ -6,7 +6,7 @@ export type Slice = {
 	weight: number
 	arcLabel: string
 	arcIconId?: WBIconID
-	titleText: string
+	ariaLabel: string
 	href?: string
 	gradient?: {
 		areaRadiusStops?: number[]

--- a/src/views/SecurityNews.svelte
+++ b/src/views/SecurityNews.svelte
@@ -133,7 +133,6 @@
 							{#if newsRefs.length > 0}
 								<ReferenceLinks
 									references={newsRefs}
-									cardBackground="tertiary"
 								/>
 							{/if}
 						</div>

--- a/src/views/WalletAttributeSummary.svelte
+++ b/src/views/WalletAttributeSummary.svelte
@@ -124,7 +124,6 @@
 					{#snippet TooltipContent()}
 						<WalletStageSummary
 							{wallet}
-							{ladders}
 							stage={firstStage}
 							{ladderEvaluation}
 							showNextStageCriteria={false}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -249,7 +249,7 @@
 				color: group.accentColor ?? 'transparent',
 				weight: 1,
 				arcLabel: '',
-				titleText: group.title,
+				ariaLabel: group.title,
 				children: (group.children ?? []).map(attribute => ({
 					id: attribute.id,
 					color: attribute.accentColor ?? 'transparent',
@@ -257,7 +257,7 @@
 						({ attribute: sourceAttribute }) => `#${slugifyCamelCase(sourceAttribute.id)}` === attribute.href
 					)?.weight ?? 1,
 					arcLabel: '',
-					titleText: attribute.title,
+					ariaLabel: attribute.title,
 				})),
 			}
 		})

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1100,7 +1100,8 @@
 										return {
 											id: `attrGroup_${attrGroup.id}`,
 											arcLabel: (groupScore !== null && groupScore.hasUnratedComponent) ? '*' : '',
-										arcIconId: attrGroup.icon,
+											arcIconId: attrGroup.icon,
+											ariaLabel: attrGroup.displayName,
 											color: (
 												groupScore !== null ?
 													scoreToColor(groupScore.score)
@@ -1127,11 +1128,12 @@
 															color: ratingToColor(attribute.evaluation.outcome.rating),
 															weight: (
 																attrGroup.attributes.find(w => w.attribute.id === attributeId)
-																	?.weight
-																?? 1
-															),
-															arcLabel: '',
-															arcIconId: attribute.attribute.icon,
+																			?.weight
+																		?? 1
+																	),
+																	arcLabel: '',
+																	arcIconId: attribute.attribute.icon,
+																	ariaLabel: `${attribute.attribute.displayName}: ${attribute.evaluation.outcome.rating}`,
 															...attribute.evaluation.outcome.rating === Rating.EXEMPT && {
 																opacity: 0.33,
 															},
@@ -1350,6 +1352,7 @@
 												),
 												arcLabel: '',
 												arcIconId: attribute.attribute.icon,
+												ariaLabel: `${attribute.attribute.displayName}${tooltipSuffix ?? ''}: ${attribute.evaluation.outcome.rating}`,
 												...attribute.evaluation.outcome.rating === Rating.EXEMPT && {
 													opacity: 0.33,
 												},
@@ -1509,7 +1512,8 @@
 												color: ratingToColor(attribute.evaluation.outcome.rating),
 												weight: 1,
 												arcLabel: '',
-												arcIconId: attribute.icon,
+												arcIconId: attribute.attribute.icon,
+												ariaLabel: `${attribute.attribute.displayName}: ${attribute.evaluation.outcome.rating}`,
 											}
 										]
 									:
@@ -1627,6 +1631,7 @@
 									id: `m_${wallet.metadata.id}_ag_${attrGroup.id}`,
 									arcLabel: (groupScore !== null && groupScore.hasUnratedComponent) ? '*' : '',
 									arcIconId: attrGroup.icon,
+									ariaLabel: attrGroup.displayName,
 									color: groupScore !== null ? scoreToColor(groupScore.score) : 'var(--rating-unrated)',
 									gradient: attributeGroupFlowerGradient,
 									weight: 1,
@@ -1647,6 +1652,7 @@
 													),
 													arcLabel: '',
 													arcIconId: attribute.attribute.icon,
+													ariaLabel: `${attribute.attribute.displayName}: ${attribute.evaluation.outcome.rating}`,
 													...attribute.evaluation.outcome.rating === Rating.EXEMPT && { opacity: 0.33 },
 												}))
 										),


### PR DESCRIPTION
cluster 4 of #1178

## Summary
- separate Pie slice accessibility labels from native hover tooltips
- remove the stale ladders prop passed to WalletStageSummary
- remove the unsupported tertiary ReferenceLinks card tone

