### PR TITLE
Shrink CalendarDate range to speed up type checking

### DIFF
--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -8,12 +8,15 @@ type MonthAndDay =
 	| `${ThirtyDayMonths}-${ThirtyDays}`
 	| `${ThirtyOneDayMonths}-${ThirtyOneDays}`
 	| `02-${FebruaryDays}`
-type Century = '20' | '21' // We're good from 2000 to 2199.
+// Keep this range no wider than the data needs: `CalendarDate` expands to one member per day it
+// covers, and check time grows faster than that count does.
+type Year = `20${'1' | '2' | '3'}${Digit}` // We're good from 2010 to 2039.
 
 /** A valid date in YYYY-MM-DD format. */
-export type CalendarDate = `${Century}${Digit}${Digit}-${MonthAndDay}`
+export type CalendarDate = `${Year}-${MonthAndDay}`
 
-const CALENDAR_DATE_PATTERN = /^(20|21)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/
+// Must accept the same years as `Year`, so `assertCalendarDate` cannot return a value the type rejects.
+const CALENDAR_DATE_PATTERN = /^20[123]\d-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/
 
 /** Check whether a string is a valid CalendarDate. */
 function isCalendarDate(date: string): date is CalendarDate {

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -73,10 +73,8 @@ export function today(): CalendarDate {
 	const year = date.getFullYear().toString()
 	const month = (date.getMonth() + 1).toString().padStart(2, '0')
 	const day = date.getDate().toString().padStart(2, '0')
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- We assume that today's date is within the set of allowed dates in CalendarDate.
-	const calendarDate = `${year}-${month}-${day}` as CalendarDate
 
-	return calendarDate
+	return assertCalendarDate(`${year}-${month}-${day}`)
 }
 
 /** Return the number of days between two CalendarDates. */

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
-import { assertCalendarDate, today } from '@/types/date'
+import { assertCalendarDate, type CalendarDate, today } from '@/types/date'
 
 // `CalendarDate` covers a fixed range of years. These tests catch today's date falling outside it,
 // and `CALENDAR_DATE_PATTERN` drifting away from it.
@@ -18,6 +18,13 @@ describe('datesAreWithinSupportedYearRange', () => {
 	it('accepts the first and last day of the range', () => {
 		expect(assertCalendarDate('2010-01-01')).toBe('2010-01-01')
 		expect(assertCalendarDate('2039-12-31')).toBe('2039-12-31')
+	})
+
+	it('expresses the supported year range in the type', () => {
+		expectTypeOf<'2009-12-31'>().not.toExtend<CalendarDate>()
+		expectTypeOf<'2010-01-01'>().toExtend<CalendarDate>()
+		expectTypeOf<'2039-12-31'>().toExtend<CalendarDate>()
+		expectTypeOf<'2040-01-01'>().not.toExtend<CalendarDate>()
 	})
 
 	it('rejects dates the type cannot express', () => {

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertCalendarDate, today } from '@/types/date'
+
+// `CalendarDate` covers a fixed range of years. These tests catch today's date falling outside it,
+// and `CALENDAR_DATE_PATTERN` drifting away from it.
+describe('datesAreWithinSupportedYearRange', () => {
+	it('accepts today', () => {
+		expect(() => assertCalendarDate(today())).not.toThrow()
+	})
+
+	it('rejects years outside the range the type allows', () => {
+		expect(() => assertCalendarDate('2009-12-31')).toThrow('Invalid calendar date')
+		expect(() => assertCalendarDate('2040-01-01')).toThrow('Invalid calendar date')
+		expect(() => assertCalendarDate('2150-01-01')).toThrow('Invalid calendar date')
+	})
+
+	it('accepts the first and last day of the range', () => {
+		expect(assertCalendarDate('2010-01-01')).toBe('2010-01-01')
+		expect(assertCalendarDate('2039-12-31')).toBe('2039-12-31')
+	})
+
+	it('rejects dates the type cannot express', () => {
+		expect(() => assertCalendarDate('2026-13-01')).toThrow('Invalid calendar date')
+		expect(() => assertCalendarDate('2026-04-31')).toThrow('Invalid calendar date')
+		expect(() => assertCalendarDate('2026-9-10')).toThrow('Invalid calendar date')
+	})
+
+	it('rejects a February 29th that the type cannot rule out', () => {
+		expect(() => assertCalendarDate('2023-02-29')).toThrow('Invalid calendar date')
+		expect(assertCalendarDate('2024-02-29')).toBe('2024-02-29')
+	})
+})


### PR DESCRIPTION
## Issue

TypeScript expands template literal types over finite unions into every member. `CalendarDate` covered years 2000-2199, making it a **73,200-member** union that every `CalendarDate` reference and every date literal in `data/` got checked against, re-instantiated inside generics. That dominated the check phase.

## Fix

The year range is the whole lever, and it was far wider than the data needs — committed dates span 2014-2026. Narrowing to 2010-2039 cuts the union to 10,980 members:

| | before | after |
|---|---|---|
| `astro check` | 162.8s | **20.7s** |
| `tsc --noEmit` check time | 150.6s | **7.7s** |

This deliberately narrows the accepted date domain from 2000-2199 to 2010-2039. No committed date literals need to change, and `CalendarDate` continues to validate the exact four-digit `YYYY-MM-DD` shape and each month's valid day range within the supported years. `MonthAndDay` is left alone because its 366 members encode month-length validation (April has no 31st).

The runtime and type boundaries are kept aligned:

- `CALENDAR_DATE_PATTERN` accepts the same years as `Year`, so `assertCalendarDate` cannot return a value the type rejects.
- `today()` passes its generated string through `assertCalendarDate` instead of using an unsafe assertion.
- `tests/date.test.ts` pins the first accepted year, last accepted year, and adjacent rejected years at both runtime and compile time. The test of today's date will fail clearly when the supported range eventually needs extending.

## Alternatives

PR #1202 explored loosening the year to `${number}` and reached a similar check time. That let `'20260-09-10'` type-check and needed a 196-line test with a hand-maintained list of date field names — a list that silently skips validation when someone adds a new `CalendarDate` field and doesn't register it.

**Branding** (`string & { readonly [brand]: unique symbol }`) measures 3.8s, has no year ceiling, and would catch leap years no template literal type can express. It was not chosen here because it means wrapping ~165 existing literals in `assertCalendarDate(...)`, conflicting with every in-flight PR touching `data/`, and adds permanent ceremony to contributor-facing wallet files. This change remains small and reversible, so it does not foreclose branding later.
